### PR TITLE
[codex] Selector de historial de sala de espera medica

### DIFF
--- a/src/api/Doctors/get-waiting-room-history.action.ts
+++ b/src/api/Doctors/get-waiting-room-history.action.ts
@@ -1,0 +1,39 @@
+import { apiTurnos } from "@/services/axiosConfig";
+import type { AppointmentFullResponseDto } from "@/types/Appointment/Appointment";
+import type { OverturnDetailedDto } from "@/types/Overturn/Overturn";
+
+export type DoctorWaitingRoomHistoryPreset =
+  | "today"
+  | "yesterday"
+  | "last7"
+  | "date"
+  | "range";
+
+export interface DoctorWaitingRoomHistoryParams {
+  preset?: DoctorWaitingRoomHistoryPreset;
+  date?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface DoctorWaitingRoomHistoryResponse {
+  preset: DoctorWaitingRoomHistoryPreset;
+  timezone: "America/Argentina/Buenos_Aires";
+  dateFrom: string;
+  dateTo: string;
+  requestedDates: string[];
+  workedDates: string[];
+  nonWorkingDates: string[];
+  appointments: AppointmentFullResponseDto[];
+  overturns: OverturnDetailedDto[];
+}
+
+export const getDoctorWaitingRoomHistory = async (
+  params: DoctorWaitingRoomHistoryParams,
+): Promise<DoctorWaitingRoomHistoryResponse> => {
+  const { data } = await apiTurnos.get<DoctorWaitingRoomHistoryResponse>(
+    "doctors/me/waiting-room-history",
+    { params },
+  );
+  return data;
+};

--- a/src/hooks/Doctor/useDoctorWaitingRoomHistory.helpers.ts
+++ b/src/hooks/Doctor/useDoctorWaitingRoomHistory.helpers.ts
@@ -1,0 +1,70 @@
+import type { AgendaItem, AgendaStats } from "@/hooks/Doctor/useDoctorDayAgenda";
+import { AppointmentStatus } from "@/types/Appointment/Appointment";
+import { OverturnStatus } from "@/types/Overturn/Overturn";
+import type { DoctorWaitingRoomHistoryResponse } from "@/api/Doctors/get-waiting-room-history.action";
+
+const isPending = (status: AgendaItem["status"]): boolean =>
+  status === AppointmentStatus.PENDING ||
+  status === OverturnStatus.PENDING ||
+  status === AppointmentStatus.REQUESTED_BY_PATIENT ||
+  status === AppointmentStatus.ASSIGNED_BY_SECRETARY;
+
+const isWaiting = (status: AgendaItem["status"]): boolean =>
+  status === AppointmentStatus.WAITING || status === OverturnStatus.WAITING;
+
+const isAttending = (status: AgendaItem["status"]): boolean =>
+  status === AppointmentStatus.ATTENDING ||
+  status === OverturnStatus.ATTENDING;
+
+const isCompleted = (status: AgendaItem["status"]): boolean =>
+  status === AppointmentStatus.COMPLETED ||
+  status === OverturnStatus.COMPLETED;
+
+const isCancelled = (status: AgendaItem["status"]): boolean =>
+  status === AppointmentStatus.CANCELLED_BY_PATIENT ||
+  status === AppointmentStatus.CANCELLED_BY_SECRETARY ||
+  status === OverturnStatus.CANCELLED_BY_PATIENT ||
+  status === OverturnStatus.CANCELLED_BY_SECRETARY;
+
+export const toDoctorWaitingRoomHistoryAgenda = (
+  response?: DoctorWaitingRoomHistoryResponse,
+): AgendaItem[] => {
+  if (!response) return [];
+
+  return [
+    ...response.appointments.map(
+      (appointment): AgendaItem => ({
+        id: appointment.id,
+        type: "appointment",
+        hour: appointment.hour,
+        date: appointment.date,
+        status: appointment.status,
+        patient: appointment.patient ?? null,
+        rawData: appointment,
+      }),
+    ),
+    ...response.overturns.map(
+      (overturn): AgendaItem => ({
+        id: overturn.id,
+        type: "overturn",
+        hour: overturn.hour,
+        date: overturn.date,
+        status: overturn.status,
+        patient: overturn.patient ?? null,
+        rawData: overturn,
+      }),
+    ),
+  ].sort((a, b) => {
+    const dateOrder = a.date.localeCompare(b.date);
+    return dateOrder !== 0 ? dateOrder : a.hour.localeCompare(b.hour);
+  });
+};
+
+export const buildAgendaStats = (agenda: AgendaItem[]): AgendaStats => ({
+  total: agenda.length,
+  pending: agenda.filter((item) => isPending(item.status)).length,
+  waiting: agenda.filter((item) => isWaiting(item.status)).length,
+  attending: agenda.filter((item) => isAttending(item.status)).length,
+  completed: agenda.filter((item) => isCompleted(item.status)).length,
+  cancelled: agenda.filter((item) => isCancelled(item.status)).length,
+});

--- a/src/hooks/Doctor/useDoctorWaitingRoomHistory.test.ts
+++ b/src/hooks/Doctor/useDoctorWaitingRoomHistory.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { AppointmentStatus } from "@/types/Appointment/Appointment";
+import { OverturnStatus } from "@/types/Overturn/Overturn";
+import {
+  buildAgendaStats,
+  toDoctorWaitingRoomHistoryAgenda,
+} from "./useDoctorWaitingRoomHistory.helpers";
+import type { DoctorWaitingRoomHistoryResponse } from "@/api/Doctors/get-waiting-room-history.action";
+
+const response: DoctorWaitingRoomHistoryResponse = {
+  preset: "last7",
+  timezone: "America/Argentina/Buenos_Aires",
+  dateFrom: "2026-05-07",
+  dateTo: "2026-05-13",
+  requestedDates: ["2026-05-12", "2026-05-13"],
+  workedDates: ["2026-05-12"],
+  nonWorkingDates: ["2026-05-13"],
+  appointments: [
+    {
+      id: 10,
+      doctorId: 7,
+      patientId: 51,
+      date: "2026-05-12",
+      hour: "10:00",
+      status: AppointmentStatus.COMPLETED,
+      isGuest: false,
+      createdAt: "2026-05-12T12:00:00.000Z",
+      updatedAt: "2026-05-12T12:00:00.000Z",
+      patient: {
+        userId: 51,
+        firstName: "Juan",
+        lastName: "Perez",
+      },
+    },
+  ],
+  overturns: [
+    {
+      id: 20,
+      doctorId: 7,
+      patientId: 52,
+      date: "2026-05-12",
+      hour: "09:30",
+      status: OverturnStatus.CANCELLED_BY_SECRETARY,
+      isGuest: false,
+      createdBy: 2,
+      createdAt: "2026-05-12T12:00:00.000Z",
+      patient: {
+        userId: 52,
+        firstName: "Maria",
+        lastName: "Gomez",
+      },
+    },
+  ],
+};
+
+describe("useDoctorWaitingRoomHistory helpers", () => {
+  it("maps backend history into sorted agenda items", () => {
+    const agenda = toDoctorWaitingRoomHistoryAgenda(response);
+
+    expect(agenda).toHaveLength(2);
+    expect(agenda[0]).toMatchObject({
+      id: 20,
+      type: "overturn",
+      hour: "09:30",
+    });
+    expect(agenda[1]).toMatchObject({
+      id: 10,
+      type: "appointment",
+      hour: "10:00",
+    });
+  });
+
+  it("builds completed and cancelled stats for historical agenda", () => {
+    const agenda = toDoctorWaitingRoomHistoryAgenda(response);
+
+    expect(buildAgendaStats(agenda)).toMatchObject({
+      total: 2,
+      completed: 1,
+      cancelled: 1,
+      waiting: 0,
+      attending: 0,
+    });
+  });
+});

--- a/src/hooks/Doctor/useDoctorWaitingRoomHistory.ts
+++ b/src/hooks/Doctor/useDoctorWaitingRoomHistory.ts
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getDoctorWaitingRoomHistory,
+  type DoctorWaitingRoomHistoryParams,
+  type DoctorWaitingRoomHistoryResponse,
+} from "@/api/Doctors/get-waiting-room-history.action";
+import useUserRole from "@/hooks/useRoles";
+import {
+  buildAgendaStats,
+  toDoctorWaitingRoomHistoryAgenda,
+} from "./useDoctorWaitingRoomHistory.helpers";
+
+export const doctorWaitingRoomHistoryKeys = {
+  all: ["doctorWaitingRoomHistory"] as const,
+  period: (params: DoctorWaitingRoomHistoryParams) =>
+    [
+      ...doctorWaitingRoomHistoryKeys.all,
+      params.preset ?? "today",
+      params.date ?? null,
+      params.dateFrom ?? null,
+      params.dateTo ?? null,
+    ] as const,
+};
+
+interface UseDoctorWaitingRoomHistoryOptions {
+  params: DoctorWaitingRoomHistoryParams;
+  enabled?: boolean;
+}
+
+export const useDoctorWaitingRoomHistory = (
+  options: UseDoctorWaitingRoomHistoryOptions,
+) => {
+  const { isDoctor } = useUserRole();
+  const enabled = (options.enabled ?? true) && isDoctor;
+
+  const query = useQuery({
+    queryKey: doctorWaitingRoomHistoryKeys.period(options.params),
+    queryFn: () => getDoctorWaitingRoomHistory(options.params),
+    enabled,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const agenda = toDoctorWaitingRoomHistoryAgenda(query.data);
+
+  return {
+    response: query.data,
+    agenda,
+    stats: buildAgendaStats(agenda),
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};
+
+export type {
+  DoctorWaitingRoomHistoryParams,
+  DoctorWaitingRoomHistoryResponse,
+};

--- a/src/pages/protected/Doctor-Waiting-Room/index.tsx
+++ b/src/pages/protected/Doctor-Waiting-Room/index.tsx
@@ -24,6 +24,14 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import {
   Users,
   UserCheck,
   MoreHorizontal,
@@ -38,8 +46,9 @@ import {
   Stethoscope,
   AlertTriangle,
   CalendarOff,
+  CalendarDays,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import {
   useDoctorDayAgenda,
@@ -51,6 +60,10 @@ import {
 } from '@/hooks/Doctor/useDoctorDayAgenda';
 import { useDoctorWaitingQueue, doctorWaitingQueueKeys } from '@/hooks/Doctor/useDoctorWaitingQueue';
 import { useDoctorWorkingToday } from '@/hooks/Doctor/useDoctorWorkingToday';
+import {
+  doctorWaitingRoomHistoryKeys,
+  useDoctorWaitingRoomHistory,
+} from '@/hooks/Doctor/useDoctorWaitingRoomHistory';
 import { useDoctorMarkAsAttending, doctorQueueKeys } from '@/hooks/Queue/useDoctorQueue';
 import { useAppointmentMutations } from '@/hooks/Appointments/useAppointmentMutations';
 import { useOverturnMutations } from '@/hooks/Overturns/useOverturnMutations';
@@ -69,6 +82,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { slugify, formatWaitingTime, getWaitingTimeColor } from '@/common/helpers/helpers';
 import { PageHeader } from '@/components/PageHeader';
 import { getAppointmentConsultationTypeSummary } from '@/common/helpers/appointment-consultation-types';
+import { getArgentinaTodayDate } from '@/common/helpers/argentinaDate';
 
 // ============================================
 // HELPERS
@@ -102,6 +116,24 @@ const getConsultationTypeName = (item: AgendaItem): string | null => {
   if (item.type !== 'appointment') return null;
   const apt = item.rawData as AppointmentFullResponseDto;
   return getAppointmentConsultationTypeSummary(apt);
+};
+
+type HistorySelectorValue = 'today' | 'yesterday' | 'last7' | 'date';
+
+const formatHistoryDate = (date: string): string => {
+  const [year, month, day] = date.split('-');
+  if (!year || !month || !day) return date;
+  return `${day}/${month}/${year}`;
+};
+
+const getHistoryPeriodLabel = (
+  value: HistorySelectorValue,
+  customDate: string,
+): string => {
+  if (value === 'today') return 'Hoy';
+  if (value === 'yesterday') return 'Ayer';
+  if (value === 'last7') return 'Últimos 7 días';
+  return customDate ? formatHistoryDate(customDate) : 'Fecha puntual';
 };
 
 
@@ -170,6 +202,17 @@ const DoctorWaitingRoomPage = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [historyPeriod, setHistoryPeriod] =
+    useState<HistorySelectorValue>('today');
+  const [historyDate, setHistoryDate] = useState(getArgentinaTodayDate());
+  const isLiveHistory = historyPeriod === 'today';
+  const historyQueryParams = useMemo(
+    () =>
+      historyPeriod === 'date'
+        ? { preset: 'date' as const, date: historyDate }
+        : { preset: historyPeriod },
+    [historyDate, historyPeriod],
+  );
   const {
     shouldRestrictWaitingRoom,
     isLoading: isWorkingTodayLoading,
@@ -190,12 +233,25 @@ const DoctorWaitingRoomPage = () => {
     isFetching: isQueueFetching,
   } = useDoctorWaitingQueue({ refetchInterval: 15000 });
 
+  const {
+    agenda: historicalAgenda,
+    response: historicalResponse,
+    isLoading: isHistoricalLoading,
+    isFetching: isHistoricalFetching,
+    isError: isHistoricalError,
+  } = useDoctorWaitingRoomHistory({
+    params: historyQueryParams,
+    enabled: !isLiveHistory && (historyPeriod !== 'date' || Boolean(historyDate)),
+  });
+
   const isLoading = isAgendaLoading || isQueueLoading || isWorkingTodayLoading;
   const isFetching = isAgendaFetching || isQueueFetching;
 
   // Filtrar por estados específicos (usando agenda para attending/history)
   const attendingItems = agenda.filter((i) => isAttending(i.status));
-  const historyItems = agenda.filter((i) => isCompleted(i.status) || isCancelled(i.status));
+  const todayHistoryItems = agenda.filter((i) => isCompleted(i.status) || isCancelled(i.status));
+  const selectedHistoryItems = isLiveHistory ? todayHistoryItems : historicalAgenda;
+  const isSelectedHistoryLoading = isLiveHistory ? isLoading : isHistoricalLoading;
   const hasAttendingPatient = attendingItems.length > 0;
 
   // Mutations
@@ -207,6 +263,17 @@ const DoctorWaitingRoomPage = () => {
     queryClient.invalidateQueries({ queryKey: doctorAgendaKeys.all });
     queryClient.invalidateQueries({ queryKey: doctorWaitingQueueKeys.all });
     queryClient.invalidateQueries({ queryKey: doctorQueueKeys.all });
+    queryClient.invalidateQueries({ queryKey: doctorWaitingRoomHistoryKeys.all });
+  };
+
+  const handleHistoryPeriodChange = (value: string) => {
+    setHistoryPeriod(value as HistorySelectorValue);
+    setIsHistoryOpen(true);
+  };
+
+  const handleHistoryDateChange = (value: string) => {
+    setHistoryDate(value);
+    setIsHistoryOpen(true);
   };
 
   const handleOpenHistoriaClinica = (item: AgendaItem) => {
@@ -518,6 +585,20 @@ const DoctorWaitingRoomPage = () => {
 
   // Historial colapsable
   const renderHistory = () => {
+    const showDateColumn =
+      !isLiveHistory &&
+      Boolean(historicalResponse) &&
+      historicalResponse?.dateFrom !== historicalResponse?.dateTo;
+    const nonWorkingCount = historicalResponse?.nonWorkingDates.length ?? 0;
+    const hasNoWorkedDates =
+      !isLiveHistory &&
+      Boolean(historicalResponse) &&
+      historicalResponse?.workedDates.length === 0;
+
+    const emptyMessage = hasNoWorkedDates
+      ? 'No fue un día de atención del médico.'
+      : 'No hay turnos completados o cancelados';
+
     return (
       <Collapsible open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
         <Card className="shadow-lg">
@@ -528,7 +609,7 @@ const DoctorWaitingRoomPage = () => {
                   <div className="p-2 rounded-lg bg-gradient-to-br from-gray-500 to-gray-600">
                     <Clock className="h-5 w-5 text-white" />
                   </div>
-                  Historial del Día ({historyItems.length})
+                  Historial ({selectedHistoryItems.length})
                 </div>
                 {isHistoryOpen ? (
                   <ChevronUp className="h-5 w-5 text-gray-500" />
@@ -539,16 +620,75 @@ const DoctorWaitingRoomPage = () => {
             </CardHeader>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <CardContent>
-              {historyItems.length === 0 ? (
+            <CardContent className="space-y-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                  <div className="w-full sm:w-56">
+                    <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                      Período
+                    </label>
+                    <Select
+                      value={historyPeriod}
+                      onValueChange={handleHistoryPeriodChange}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccionar período" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="today">Hoy</SelectItem>
+                        <SelectItem value="yesterday">Ayer</SelectItem>
+                        <SelectItem value="last7">Últimos 7 días</SelectItem>
+                        <SelectItem value="date">Elegir fecha</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {historyPeriod === 'date' && (
+                    <div className="w-full sm:w-44">
+                      <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                        Fecha
+                      </label>
+                      <Input
+                        type="date"
+                        value={historyDate}
+                        max={getArgentinaTodayDate()}
+                        onChange={(event) =>
+                          handleHistoryDateChange(event.target.value)
+                        }
+                      />
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <CalendarDays className="h-4 w-4" />
+                  <span>
+                    {getHistoryPeriodLabel(historyPeriod, historyDate)}
+                    {!isLiveHistory && nonWorkingCount > 0
+                      ? ` · ${nonWorkingCount} día${nonWorkingCount === 1 ? '' : 's'} sin horario`
+                      : ''}
+                  </span>
+                </div>
+              </div>
+
+              {isSelectedHistoryLoading ? (
+                <div className="space-y-2">
+                  {[...Array(3)].map((_, index) => (
+                    <Skeleton key={index} className="h-12 w-full" />
+                  ))}
+                </div>
+              ) : isHistoricalError && !isLiveHistory ? (
+                <p className="text-center py-4 text-red-600">
+                  No se pudo cargar el historial seleccionado.
+                </p>
+              ) : selectedHistoryItems.length === 0 ? (
                 <p className="text-center py-4 text-muted-foreground">
-                  No hay turnos completados o cancelados
+                  {emptyMessage}
                 </p>
               ) : (
                 <div className="rounded-lg border overflow-hidden overflow-x-auto">
                   <Table>
                     <TableHeader>
                       <TableRow className="bg-gray-50">
+                        {showDateColumn && <TableHead>Fecha</TableHead>}
                         <TableHead>Hora</TableHead>
                         <TableHead>Paciente</TableHead>
                         <TableHead>Tipo</TableHead>
@@ -558,8 +698,11 @@ const DoctorWaitingRoomPage = () => {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {historyItems.map((item) => (
-                        <TableRow key={`${item.type}-${item.id}`} className="opacity-70 hover:opacity-100 transition-opacity">
+                      {selectedHistoryItems.map((item) => (
+                        <TableRow key={`${item.type}-${item.date}-${item.id}`} className="opacity-70 hover:opacity-100 transition-opacity">
+                          {showDateColumn && (
+                            <TableCell>{formatHistoryDate(item.date)}</TableCell>
+                          )}
                           <TableCell className="font-mono">{item.hour}</TableCell>
                           <TableCell>{renderPatientName(item)}</TableCell>
                           <TableCell>
@@ -625,10 +768,14 @@ const DoctorWaitingRoomPage = () => {
           <Button
             variant="outline"
             onClick={handleRefresh}
-            disabled={isFetching}
+            disabled={isFetching || isHistoricalFetching}
             className="shadow-sm hover:shadow-md transition-shadow"
           >
-            <RefreshCcw className={`h-4 w-4 mr-2 ${isFetching ? 'animate-spin' : ''}`} />
+            <RefreshCcw
+              className={`h-4 w-4 mr-2 ${
+                isFetching || isHistoricalFetching ? 'animate-spin' : ''
+              }`}
+            />
             Actualizar
           </Button>
         }
@@ -651,43 +798,43 @@ const DoctorWaitingRoomPage = () => {
       ) : (
         <>
 
-      {/* Stats Cards con animaciones */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        {statsCards.map((stat, index) => (
-          <StatsCard
-            key={index}
-            title={stat.title}
-            value={stat.value}
-            icon={stat.icon}
-            gradient={stat.gradient}
-            isLoading={isLoading}
-          />
-        ))}
-      </div>
+          {/* Stats Cards con animaciones */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {statsCards.map((stat, index) => (
+              <StatsCard
+                key={index}
+                title={stat.title}
+                value={stat.value}
+                icon={stat.icon}
+                gradient={stat.gradient}
+                isLoading={isLoading}
+              />
+            ))}
+          </div>
 
-      {/* Paciente en Atención (si hay) */}
-      {renderAttendingCard()}
+          {/* Paciente en Atención (si hay) */}
+          {renderAttendingCard()}
 
-      {/* Pacientes en Espera - Vista Principal */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, delay: 0.2 }}
-      >
-        <Card className="border-orange-200 shadow-lg">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-orange-700">
-              <div className="p-2 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600">
-                <Armchair className="h-5 w-5 text-white" />
-              </div>
-              Pacientes en Espera ({waitingQueue.length})
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {renderWaitingTable()}
-          </CardContent>
-        </Card>
-      </motion.div>
+          {/* Pacientes en Espera - Vista Principal */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, delay: 0.2 }}
+          >
+            <Card className="border-orange-200 shadow-lg">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-orange-700">
+                  <div className="p-2 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600">
+                    <Armchair className="h-5 w-5 text-white" />
+                  </div>
+                  Pacientes en Espera ({waitingQueue.length})
+                </CardTitle>
+              </CardHeader>
+              <CardContent>{renderWaitingTable()}</CardContent>
+            </Card>
+          </motion.div>
+        </>
+      )}
 
       {/* Historial Colapsable */}
       <motion.div
@@ -697,8 +844,6 @@ const DoctorWaitingRoomPage = () => {
       >
         {renderHistory()}
       </motion.div>
-        </>
-      )}
     </div>
   );
 };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,54 @@
 import '@testing-library/jest-dom';
 
+class InMemoryStorage {
+  private store = new Map<string, string>();
+
+  get length() {
+    return this.store.size;
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value);
+  }
+}
+
+const ensureStorage = (storageKey: 'localStorage' | 'sessionStorage') => {
+  const storage = window[storageKey];
+  if (
+    storage &&
+    typeof storage.getItem === 'function' &&
+    typeof storage.setItem === 'function' &&
+    typeof storage.removeItem === 'function' &&
+    typeof storage.clear === 'function'
+  ) {
+    return;
+  }
+
+  Object.defineProperty(window, storageKey, {
+    configurable: true,
+    value: new InMemoryStorage(),
+  });
+};
+
+ensureStorage('localStorage');
+ensureStorage('sessionStorage');
+
 // Mock para matchMedia (necesario para algunos componentes UI)
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/src/validators/patient.schema.ts
+++ b/src/validators/patient.schema.ts
@@ -18,6 +18,8 @@ export const PatientSchema = UserSchema.extend({
  * .partial() makes all fields optional for partial updates.
  */
 export const UpdatePatientSchema = PatientSchema.extend({
+    email: z.union([z.literal(""), z.string().email()]).optional(),
+    affiliationNumber: z.string().optional(),
     healthPlans: z.array(z.object({
         id: z.number(),
         name: z.string(),


### PR DESCRIPTION
## Resumen

Agrega selector de periodo al historial de `/mi-sala-de-espera` para que el medico vea hoy, ayer, ultimos 7 dias o una fecha puntual.

## Cambios

- La vista de hoy conserva el comportamiento live con auto-refresh.
- Los historicos consumen `GET /doctors/me/waiting-room-history` sin acciones operativas de cambio de estado.
- El historial muestra completados/cancelados, fecha en rangos y metadata de dias sin horario.
- Agrega action API, hook React Query y helper testeado para mapear la respuesta historica a agenda.
- Estabiliza storage de tests y alinea `UpdatePatientSchema` para que el suite completo pase.

## Validacion

- `npm run type-check`
- `npm run build`
- `npm run lint`
- `npm run test:run` (48 files, 432 tests)

## Integracion

Fast-forward directo a `develop`: `85be87b`.

Feature: 240. Requiere API feature 239.