### PR TITLE
feat: add patient vaccination card ui

### DIFF
--- a/src/api/Vaccination/vaccination.action.ts
+++ b/src/api/Vaccination/vaccination.action.ts
@@ -1,0 +1,60 @@
+import { apiIncorHC } from "@/services/axiosConfig";
+import type {
+  CreateVaccinationApplicationDto,
+  UpdateVaccinationApplicationDto,
+  VaccinationApplication,
+  VaccinationCard,
+  VaccinationCatalog,
+} from "@/types/Vaccination/Vaccination";
+
+export const getVaccinationCatalog = async (): Promise<VaccinationCatalog> => {
+  const { data } =
+    await apiIncorHC.get<VaccinationCatalog>("/vaccination-cards/catalog");
+  return data;
+};
+
+export const getMyVaccinationCard =
+  async (): Promise<VaccinationCard | null> => {
+    const { data } =
+      await apiIncorHC.get<VaccinationCard | null>(
+        "/vaccination-cards/my-card"
+      );
+    return data;
+  };
+
+export const getPatientVaccinationCard = async (
+  patientUserId: string
+): Promise<VaccinationCard> => {
+  const { data } = await apiIncorHC.get<VaccinationCard>(
+    `/vaccination-cards/patient/${patientUserId}`
+  );
+  return data;
+};
+
+export const createVaccinationApplication = async (
+  patientUserId: string,
+  dto: CreateVaccinationApplicationDto
+): Promise<VaccinationApplication> => {
+  const { data } = await apiIncorHC.post<VaccinationApplication>(
+    `/vaccination-cards/patient/${patientUserId}/applications`,
+    dto
+  );
+  return data;
+};
+
+export const updateVaccinationApplication = async (
+  applicationId: string,
+  dto: UpdateVaccinationApplicationDto
+): Promise<VaccinationApplication> => {
+  const { data } = await apiIncorHC.patch<VaccinationApplication>(
+    `/vaccination-cards/applications/${applicationId}`,
+    dto
+  );
+  return data;
+};
+
+export const deleteVaccinationApplication = async (
+  applicationId: string
+): Promise<void> => {
+  await apiIncorHC.delete(`/vaccination-cards/applications/${applicationId}`);
+};

--- a/src/common/constants/permissions.ts
+++ b/src/common/constants/permissions.ts
@@ -57,6 +57,7 @@ export const PERMISSIONS = {
 
   // Chequeos Periódicos
   MY_CHECKUPS: [Role.PACIENTE],
+  MY_VACCINATION: [Role.PACIENTE],
 
   // Programas
   PROGRAMS: [Role.ADMINISTRADOR, Role.MEDICO, Role.PROFESOR],
@@ -76,6 +77,7 @@ export const STRICT_PERMISSIONS = [
   'DOCTOR_PRESCRIPTION_REQUESTS',
   'MY_GREEN_CARDS',
   'MY_CHECKUPS',
+  'MY_VACCINATION',
   'MY_PROGRAMS',
 ] as const;
 

--- a/src/components/Home/Patient/index.tsx
+++ b/src/components/Home/Patient/index.tsx
@@ -1,7 +1,18 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Link } from "react-router-dom";
-import { User, FileText, Calendar, ArrowRight, Sparkles, X, ClipboardList, CalendarCheck, Activity } from "lucide-react";
+import {
+  Activity,
+  ArrowRight,
+  Calendar,
+  CalendarCheck,
+  ClipboardList,
+  FileText,
+  Sparkles,
+  Syringe,
+  User,
+  X,
+} from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
@@ -70,6 +81,14 @@ export default function PatientHomePage({ name }: { name: string }) {
       icon: CalendarCheck,
       href: "/mis-chequeos",
       gradient: "from-orange-500 to-orange-600",
+      comingSoon: false,
+    },
+    {
+      title: "Mis Vacunas",
+      description: "Consulta tu carnet y vacunas pendientes",
+      icon: Syringe,
+      href: "/mis-vacunas",
+      gradient: "from-sky-500 to-cyan-600",
       comingSoon: false,
     },
     {

--- a/src/components/Patients/Modules/index.tsx
+++ b/src/components/Patients/Modules/index.tsx
@@ -1,5 +1,13 @@
 import useUserRole from "@/hooks/useRoles";
-import { Stethoscope, Calendar, FileImage, ClipboardPlus, CalendarCheck, Pill } from "lucide-react";
+import {
+  Calendar,
+  CalendarCheck,
+  ClipboardPlus,
+  FileImage,
+  Pill,
+  Stethoscope,
+  Syringe,
+} from "lucide-react";
 import { ModuleCard } from "@/components/shared/ModuleCard";
 import { useMyGreenCardServiceEnabled } from "@/hooks/Doctor-Services/useDoctorServices";
 
@@ -10,6 +18,7 @@ interface PatientModulesProps {
   onCitasMedicasClick?: () => void;
   onChequeosPeriodicosClick?: () => void;
   onCartonVerdeClick?: () => void;
+  onVacunacionClick?: () => void;
   totalStudies?: number;
 }
 
@@ -20,6 +29,7 @@ export default function PatientModules({
   onCitasMedicasClick,
   onChequeosPeriodicosClick,
   onCartonVerdeClick,
+  onVacunacionClick,
   totalStudies,
 }: PatientModulesProps) {
   const { isDoctor } = useUserRole();
@@ -49,6 +59,14 @@ export default function PatientModules({
       gradient: "bg-gradient-to-br from-green-500 to-green-600",
       onClick: onCartonVerdeClick || (() => {}),
       visible: isDoctor && hasGreenCardService,
+    },
+    {
+      title: "Vacunación",
+      description: "Carnet, vacunas aplicadas y pendientes",
+      icon: Syringe,
+      gradient: "bg-gradient-to-br from-sky-500 to-cyan-600",
+      onClick: onVacunacionClick || (() => {}),
+      visible: isDoctor,
     },
     {
       title: "Estudios e Imágenes",

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -35,6 +35,7 @@ import {
   FileText,
   Pill,
   CreditCard,
+  Syringe,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -142,6 +143,13 @@ const navigationItems = [
     url: "/mis-chequeos",
     icon: CalendarClock,
     allowedRoles: PERMISSIONS.MY_CHECKUPS,
+    strictRoles: true,
+  },
+  {
+    title: "Mis Vacunas",
+    url: "/mis-vacunas",
+    icon: Syringe,
+    allowedRoles: PERMISSIONS.MY_VACCINATION,
     strictRoles: true,
   },
   {

--- a/src/components/Vaccination/VaccinationApplicationFormModal.tsx
+++ b/src/components/Vaccination/VaccinationApplicationFormModal.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2, Syringe } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useToastContext } from "@/hooks/Toast/toast-context";
+import { useVaccinationMutations } from "@/hooks/Vaccination/useVaccinationMutations";
+import type {
+  VaccinationApplication,
+  VaccinationCatalog,
+  VaccinationScheduleRule,
+} from "@/types/Vaccination/Vaccination";
+import {
+  VaccinationApplicationFormValues,
+  VaccinationApplicationSchema,
+} from "@/validators/vaccination.schema";
+
+interface VaccinationApplicationFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  patientUserId: string;
+  catalog?: VaccinationCatalog;
+  application?: VaccinationApplication | null;
+  initialScheduleRuleId?: string;
+}
+
+const todayDateOnly = () => new Date().toISOString().slice(0, 10);
+
+export function VaccinationApplicationFormModal({
+  isOpen,
+  onClose,
+  patientUserId,
+  catalog,
+  application,
+  initialScheduleRuleId,
+}: VaccinationApplicationFormModalProps) {
+  const isEditing = Boolean(application);
+  const { showSuccess, showError } = useToastContext();
+  const { createApplicationMutation, updateApplicationMutation } =
+    useVaccinationMutations();
+
+  const rulesByVaccine = useMemo(() => {
+    const map = new Map<string, VaccinationScheduleRule[]>();
+    for (const rule of catalog?.scheduleRules ?? []) {
+      const existing = map.get(rule.vaccineId) ?? [];
+      existing.push(rule);
+      map.set(rule.vaccineId, existing);
+    }
+    return map;
+  }, [catalog?.scheduleRules]);
+
+  const form = useForm<VaccinationApplicationFormValues>({
+    resolver: zodResolver(VaccinationApplicationSchema),
+    defaultValues: {
+      scheduleRuleId: application?.scheduleRuleId ?? initialScheduleRuleId ?? "",
+      appliedDate: application?.appliedDate ?? todayDateOnly(),
+      observations: application?.observations ?? "",
+    },
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset({
+        scheduleRuleId:
+          application?.scheduleRuleId ?? initialScheduleRuleId ?? "",
+        appliedDate: application?.appliedDate ?? todayDateOnly(),
+        observations: application?.observations ?? "",
+      });
+    }
+  }, [application, form, initialScheduleRuleId, isOpen]);
+
+  const onSubmit = async (values: VaccinationApplicationFormValues) => {
+    const payload = {
+      scheduleRuleId: values.scheduleRuleId,
+      appliedDate: values.appliedDate,
+      observations: values.observations?.trim() || undefined,
+    };
+
+    try {
+      if (isEditing && application) {
+        await updateApplicationMutation.mutateAsync({
+          applicationId: application.id,
+          dto: payload,
+        });
+        showSuccess("Vacuna actualizada correctamente");
+      } else {
+        await createApplicationMutation.mutateAsync({
+          patientUserId,
+          dto: payload,
+        });
+        showSuccess("Vacuna cargada correctamente");
+      }
+      onClose();
+    } catch {
+      showError(
+        isEditing
+          ? "Error al actualizar la vacuna"
+          : "Error al cargar la vacuna"
+      );
+    }
+  };
+
+  const isLoading =
+    createApplicationMutation.isPending || updateApplicationMutation.isPending;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-[620px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-green-700">
+            <Syringe className="h-5 w-5" />
+            {isEditing ? "Editar vacuna" : "Cargar vacuna"}
+          </DialogTitle>
+          <DialogDescription>
+            Selecciona la vacuna del calendario y registra la fecha aplicada.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="scheduleRuleId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Vacuna y dosis</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={!catalog || isLoading}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccionar vacuna y dosis" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {(catalog?.vaccines ?? []).map((vaccine) => {
+                        const rules = rulesByVaccine.get(vaccine.id) ?? [];
+                        if (rules.length === 0) return null;
+
+                        return (
+                          <SelectGroup key={vaccine.id}>
+                            <SelectLabel>{vaccine.name}</SelectLabel>
+                            {rules.map((rule) => (
+                              <SelectItem key={rule.id} value={rule.id}>
+                                {rule.doseLabel}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="appliedDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Fecha de aplicacion</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      max={todayDateOnly()}
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="observations"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Observaciones</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={4}
+                      placeholder="Observaciones clinicas, lote, lugar de aplicacion..."
+                      disabled={isLoading}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isLoading}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                className="bg-green-600 hover:bg-green-700"
+                disabled={isLoading}
+              >
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isEditing ? "Guardar" : "Cargar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Vaccination/VaccinationCardView.tsx
+++ b/src/components/Vaccination/VaccinationCardView.tsx
@@ -1,0 +1,421 @@
+import { useMemo, useState } from "react";
+import {
+  AlertCircle,
+  CalendarClock,
+  CheckCircle2,
+  Edit,
+  Loader2,
+  Plus,
+  Syringe,
+  Trash2,
+  type LucideIcon,
+} from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToastContext } from "@/hooks/Toast/toast-context";
+import { useVaccinationCatalog } from "@/hooks/Vaccination/useVaccinationCard";
+import { useVaccinationMutations } from "@/hooks/Vaccination/useVaccinationMutations";
+import type {
+  VaccinationApplication,
+  VaccinationCard,
+  VaccinationCardItem,
+  VaccinationCardStatus,
+} from "@/types/Vaccination/Vaccination";
+import { VaccinationApplicationFormModal } from "./VaccinationApplicationFormModal";
+
+interface VaccinationCardViewProps {
+  vaccinationCard: VaccinationCard;
+  isDoctor?: boolean;
+}
+
+const statusMeta: Record<
+  VaccinationCardStatus,
+  {
+    label: string;
+    icon: LucideIcon;
+    badgeVariant: "success" | "warning" | "destructive" | "secondary";
+    textClassName: string;
+  }
+> = {
+  applied: {
+    label: "Aplicada",
+    icon: CheckCircle2,
+    badgeVariant: "success",
+    textClassName: "text-green-700",
+  },
+  pending: {
+    label: "Pendiente",
+    icon: AlertCircle,
+    badgeVariant: "warning",
+    textClassName: "text-yellow-700",
+  },
+  overdue: {
+    label: "Vencida",
+    icon: AlertCircle,
+    badgeVariant: "destructive",
+    textClassName: "text-red-700",
+  },
+  upcoming: {
+    label: "Proxima",
+    icon: CalendarClock,
+    badgeVariant: "secondary",
+    textClassName: "text-blue-700",
+  },
+};
+
+const tabItems: Array<{ value: VaccinationCardStatus | "all"; label: string }> =
+  [
+    { value: "all", label: "Todas" },
+    { value: "overdue", label: "Vencidas" },
+    { value: "pending", label: "Pendientes" },
+    { value: "upcoming", label: "Proximas" },
+    { value: "applied", label: "Aplicadas" },
+  ];
+
+const formatDate = (value?: string) => {
+  if (!value) return "-";
+  const [year, month, day] = value.slice(0, 10).split("-");
+  return `${day}/${month}/${year}`;
+};
+
+const formatAge = (months?: number | null) => {
+  if (months === null || months === undefined) return "-";
+  if (months === 0) return "Nacimiento";
+  if (months < 12) return `${months} mes${months === 1 ? "" : "es"}`;
+
+  const years = Math.floor(months / 12);
+  const remainingMonths = months % 12;
+  if (remainingMonths === 0) {
+    return `${years} anio${years === 1 ? "" : "s"}`;
+  }
+  return `${years} anio${years === 1 ? "" : "s"} ${remainingMonths} m`;
+};
+
+const getDoctorName = (application?: VaccinationApplication) => {
+  if (!application?.doctor) return "-";
+  return `${application.doctor.firstName} ${application.doctor.lastName}`;
+};
+
+export function VaccinationCardView({
+  vaccinationCard,
+  isDoctor = false,
+}: VaccinationCardViewProps) {
+  const [activeTab, setActiveTab] = useState<VaccinationCardStatus | "all">(
+    "all"
+  );
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [selectedApplication, setSelectedApplication] =
+    useState<VaccinationApplication | null>(null);
+  const [initialScheduleRuleId, setInitialScheduleRuleId] = useState<
+    string | undefined
+  >();
+  const [applicationToDelete, setApplicationToDelete] =
+    useState<VaccinationApplication | null>(null);
+
+  const canAddApplications =
+    isDoctor && vaccinationCard.canAddApplications === true;
+  const { catalog, isLoading: isLoadingCatalog } =
+    useVaccinationCatalog(canAddApplications);
+  const { deleteApplicationMutation } = useVaccinationMutations();
+  const { showSuccess, showError } = useToastContext();
+
+  const filteredItems = useMemo(() => {
+    if (activeTab === "all") return vaccinationCard.items;
+    return vaccinationCard.items.filter((item) => item.status === activeTab);
+  }, [activeTab, vaccinationCard.items]);
+
+  const openCreateModal = (scheduleRuleId?: string) => {
+    setSelectedApplication(null);
+    setInitialScheduleRuleId(scheduleRuleId);
+    setIsFormOpen(true);
+  };
+
+  const openEditModal = (application: VaccinationApplication) => {
+    setSelectedApplication(application);
+    setInitialScheduleRuleId(undefined);
+    setIsFormOpen(true);
+  };
+
+  const closeFormModal = () => {
+    setIsFormOpen(false);
+    setSelectedApplication(null);
+    setInitialScheduleRuleId(undefined);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!applicationToDelete) return;
+
+    try {
+      await deleteApplicationMutation.mutateAsync({
+        applicationId: applicationToDelete.id,
+      });
+      showSuccess("Vacuna eliminada correctamente");
+      setApplicationToDelete(null);
+    } catch {
+      showError("Error al eliminar la vacuna");
+    }
+  };
+
+  const renderStatusBadge = (status: VaccinationCardStatus) => {
+    const meta = statusMeta[status];
+    const Icon = meta.icon;
+
+    return (
+      <Badge variant={meta.badgeVariant} className="gap-1 whitespace-nowrap">
+        <Icon className="h-3 w-3" />
+        {meta.label}
+      </Badge>
+    );
+  };
+
+  const renderActionCell = (item: VaccinationCardItem) => {
+    const application = item.application;
+
+    if (isDoctor && application?.canEdit) {
+      return (
+        <div className="flex items-center justify-end gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-blue-600 hover:bg-blue-50 hover:text-blue-700"
+            aria-label={`Editar ${item.vaccine.name} ${item.doseLabel}`}
+            onClick={() => openEditModal(application)}
+          >
+            <Edit className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-red-600 hover:bg-red-50 hover:text-red-700"
+            aria-label={`Eliminar ${item.vaccine.name} ${item.doseLabel}`}
+            onClick={() => setApplicationToDelete(application)}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      );
+    }
+
+    if (canAddApplications && !application) {
+      return (
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 border-green-200 text-green-700 hover:bg-green-50"
+            onClick={() => openCreateModal(item.scheduleRuleId)}
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Cargar
+          </Button>
+        </div>
+      );
+    }
+
+    return <span className="text-sm text-gray-400">-</span>;
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <Card className="border-green-100 bg-green-50/60">
+          <CardContent className="p-4">
+            <p className="text-sm font-medium text-green-700">Aplicadas</p>
+            <p className="text-2xl font-bold text-green-900">
+              {vaccinationCard.counts.applied}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="border-yellow-100 bg-yellow-50/60">
+          <CardContent className="p-4">
+            <p className="text-sm font-medium text-yellow-700">Pendientes</p>
+            <p className="text-2xl font-bold text-yellow-900">
+              {vaccinationCard.counts.pending}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="border-red-100 bg-red-50/60">
+          <CardContent className="p-4">
+            <p className="text-sm font-medium text-red-700">Vencidas</p>
+            <p className="text-2xl font-bold text-red-900">
+              {vaccinationCard.counts.overdue}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="border-blue-100 bg-blue-50/60">
+          <CardContent className="p-4">
+            <p className="text-sm font-medium text-blue-700">Proximas</p>
+            <p className="text-2xl font-bold text-blue-900">
+              {vaccinationCard.counts.upcoming}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Syringe className="h-5 w-5 text-green-600" />
+              Carnet de vacunacion
+            </CardTitle>
+            {canAddApplications && (
+              <Button
+                onClick={() => openCreateModal()}
+                className="bg-green-600 hover:bg-green-700"
+                disabled={isLoadingCatalog}
+              >
+                {isLoadingCatalog ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="mr-2 h-4 w-4" />
+                )}
+                Cargar vacuna
+              </Button>
+            )}
+          </div>
+
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) =>
+              setActiveTab(value as VaccinationCardStatus | "all")
+            }
+          >
+            <TabsList className="flex h-auto w-full flex-wrap justify-start gap-1 p-1">
+              {tabItems.map((tab) => (
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  className="min-w-[96px] flex-1"
+                >
+                  {tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-32">Estado</TableHead>
+                  <TableHead>Vacuna</TableHead>
+                  <TableHead>Dosis</TableHead>
+                  <TableHead className="w-28">Edad</TableHead>
+                  <TableHead className="w-32">Recomendada</TableHead>
+                  <TableHead className="w-32">Aplicada</TableHead>
+                  <TableHead>Observaciones</TableHead>
+                  <TableHead className="w-24 text-right">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={8}
+                      className="py-8 text-center text-gray-500"
+                    >
+                      No hay vacunas para el filtro seleccionado
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredItems.map((item) => (
+                    <TableRow key={item.scheduleRuleId}>
+                      <TableCell>{renderStatusBadge(item.status)}</TableCell>
+                      <TableCell>
+                        <div className="font-medium text-gray-900">
+                          {item.vaccine.name}
+                        </div>
+                        {item.notes && (
+                          <div className="mt-1 max-w-[260px] text-xs text-gray-500">
+                            {item.notes}
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-gray-700">
+                        {item.doseLabel}
+                      </TableCell>
+                      <TableCell>{formatAge(item.recommendedAgeMonths)}</TableCell>
+                      <TableCell>{formatDate(item.recommendedDate)}</TableCell>
+                      <TableCell>
+                        <div className={statusMeta[item.status].textClassName}>
+                          {formatDate(item.application?.appliedDate)}
+                        </div>
+                        {item.application?.doctor && (
+                          <div className="mt-1 text-xs text-gray-500">
+                            {getDoctorName(item.application)}
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell className="max-w-[260px] text-sm text-gray-600">
+                        {item.application?.observations || "-"}
+                      </TableCell>
+                      <TableCell>{renderActionCell(item)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <VaccinationApplicationFormModal
+        isOpen={isFormOpen}
+        onClose={closeFormModal}
+        patientUserId={vaccinationCard.patientUserId}
+        catalog={catalog}
+        application={selectedApplication}
+        initialScheduleRuleId={initialScheduleRuleId}
+      />
+
+      <AlertDialog
+        open={Boolean(applicationToDelete)}
+        onOpenChange={(open) => {
+          if (!open) setApplicationToDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Eliminar vacuna aplicada</AlertDialogTitle>
+            <AlertDialogDescription>
+              El registro dejara de verse en el carnet de vacunacion del
+              paciente.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/Vaccination/__tests__/VaccinationCardView.test.tsx
+++ b/src/components/Vaccination/__tests__/VaccinationCardView.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VaccinationCardView } from "../VaccinationCardView";
+import type { VaccinationCard } from "@/types/Vaccination/Vaccination";
+
+const mocks = vi.hoisted(() => ({
+  useVaccinationCatalog: vi.fn(),
+  createApplicationMutation: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+  updateApplicationMutation: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+  deleteApplicationMutation: {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  },
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+vi.mock("@/hooks/Vaccination/useVaccinationCard", () => ({
+  useVaccinationCatalog: mocks.useVaccinationCatalog,
+}));
+
+vi.mock("@/hooks/Vaccination/useVaccinationMutations", () => ({
+  useVaccinationMutations: () => ({
+    createApplicationMutation: mocks.createApplicationMutation,
+    updateApplicationMutation: mocks.updateApplicationMutation,
+    deleteApplicationMutation: mocks.deleteApplicationMutation,
+  }),
+}));
+
+vi.mock("@/hooks/Toast/toast-context", () => ({
+  useToastContext: () => ({
+    showSuccess: mocks.showSuccess,
+    showError: mocks.showError,
+  }),
+}));
+
+const vaccinationCard: VaccinationCard = {
+  patientUserId: "patient-uuid",
+  generatedAt: "2026-05-13",
+  canAddApplications: true,
+  counts: {
+    applied: 1,
+    pending: 0,
+    overdue: 1,
+    upcoming: 1,
+  },
+  applications: [],
+  items: [
+    {
+      scheduleRuleId: "rule-applied",
+      vaccineId: "vaccine-triple",
+      vaccine: {
+        id: "vaccine-triple",
+        code: "triple_viral",
+        name: "Triple viral",
+        active: true,
+      },
+      doseLabel: "1ra dosis",
+      recommendedAgeMonths: 12,
+      overdueAgeMonths: 13,
+      recommendedDate: "2021-01-15",
+      overdueDate: "2021-02-15",
+      status: "applied",
+      application: {
+        id: "application-uuid",
+        patientUserId: "patient-uuid",
+        vaccineId: "vaccine-triple",
+        scheduleRuleId: "rule-applied",
+        doseLabel: "1ra dosis",
+        appliedDate: "2021-01-20",
+        observations: "Sin reacciones",
+        doctorUserId: "doctor-uuid",
+        canEdit: true,
+        doctor: {
+          id: "doctor-uuid",
+          firstName: "Carlos",
+          lastName: "Gomez",
+        },
+      },
+    },
+    {
+      scheduleRuleId: "rule-overdue",
+      vaccineId: "vaccine-vph",
+      vaccine: {
+        id: "vaccine-vph",
+        code: "vph",
+        name: "VPH",
+        active: true,
+      },
+      doseLabel: "Unica dosis",
+      recommendedAgeMonths: 132,
+      overdueAgeMonths: 144,
+      recommendedDate: "2031-01-15",
+      overdueDate: "2032-01-15",
+      status: "overdue",
+    },
+    {
+      scheduleRuleId: "rule-upcoming",
+      vaccineId: "vaccine-dtpa",
+      vaccine: {
+        id: "vaccine-dtpa",
+        code: "dtpa",
+        name: "dTpa",
+        active: true,
+      },
+      doseLabel: "11 anios",
+      recommendedAgeMonths: 132,
+      overdueAgeMonths: 144,
+      recommendedDate: "2031-01-15",
+      overdueDate: "2032-01-15",
+      status: "upcoming",
+    },
+  ],
+};
+
+describe("VaccinationCardView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useVaccinationCatalog.mockReturnValue({
+      catalog: {
+        vaccines: [],
+        scheduleRules: [],
+      },
+      isLoading: false,
+    });
+  });
+
+  it("renders the card in patient read-only mode", () => {
+    render(
+      <VaccinationCardView
+        vaccinationCard={{ ...vaccinationCard, canAddApplications: false }}
+      />
+    );
+
+    expect(screen.getByText("Carnet de vacunacion")).toBeInTheDocument();
+    expect(screen.getByText("Triple viral")).toBeInTheDocument();
+    expect(screen.getByText("Sin reacciones")).toBeInTheDocument();
+    expect(screen.getByText("Vencida")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /cargar vacuna/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /editar triple viral/i })
+    ).not.toBeInTheDocument();
+    expect(mocks.useVaccinationCatalog).toHaveBeenCalledWith(false);
+  });
+
+  it("shows doctor actions when the card allows applications", () => {
+    render(<VaccinationCardView vaccinationCard={vaccinationCard} isDoctor />);
+
+    expect(
+      screen.getByRole("button", { name: /cargar vacuna/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /editar triple viral 1ra dosis/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /eliminar triple viral 1ra dosis/i })
+    ).toBeInTheDocument();
+    expect(mocks.useVaccinationCatalog).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/hooks/Vaccination/useVaccinationCard.ts
+++ b/src/hooks/Vaccination/useVaccinationCard.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getMyVaccinationCard,
+  getPatientVaccinationCard,
+  getVaccinationCatalog,
+} from "@/api/Vaccination/vaccination.action";
+
+interface UsePatientVaccinationCardProps {
+  patientUserId: string;
+  enabled?: boolean;
+}
+
+interface UseMyVaccinationCardProps {
+  enabled?: boolean;
+}
+
+export const useVaccinationCatalog = (enabled = true) => {
+  const { data, isLoading, isFetching, error } = useQuery({
+    queryKey: ["vaccination-catalog"],
+    queryFn: getVaccinationCatalog,
+    staleTime: 1000 * 60 * 30,
+    enabled,
+  });
+
+  return {
+    catalog: data,
+    isLoading,
+    isFetching,
+    error,
+  };
+};
+
+export const useMyVaccinationCard = ({
+  enabled = true,
+}: UseMyVaccinationCardProps = {}) => {
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: ["my-vaccination-card"],
+    queryFn: getMyVaccinationCard,
+    staleTime: 1000 * 60,
+    enabled,
+  });
+
+  return {
+    vaccinationCard: data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  };
+};
+
+export const usePatientVaccinationCard = ({
+  patientUserId,
+  enabled = true,
+}: UsePatientVaccinationCardProps) => {
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: ["patient-vaccination-card", patientUserId],
+    queryFn: () => getPatientVaccinationCard(patientUserId),
+    staleTime: 1000 * 60,
+    enabled: patientUserId !== "" && enabled,
+  });
+
+  return {
+    vaccinationCard: data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  };
+};

--- a/src/hooks/Vaccination/useVaccinationMutations.ts
+++ b/src/hooks/Vaccination/useVaccinationMutations.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  createVaccinationApplication,
+  deleteVaccinationApplication,
+  updateVaccinationApplication,
+} from "@/api/Vaccination/vaccination.action";
+import type {
+  CreateVaccinationApplicationDto,
+  UpdateVaccinationApplicationDto,
+} from "@/types/Vaccination/Vaccination";
+
+export const useVaccinationMutations = () => {
+  const queryClient = useQueryClient();
+
+  const invalidateVaccinationQueries = (patientUserId?: string) => {
+    queryClient.invalidateQueries({ queryKey: ["my-vaccination-card"] });
+    if (patientUserId) {
+      queryClient.invalidateQueries({
+        queryKey: ["patient-vaccination-card", patientUserId],
+      });
+    } else {
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey[0] === "patient-vaccination-card",
+      });
+    }
+  };
+
+  const createApplicationMutation = useMutation({
+    mutationFn: ({
+      patientUserId,
+      dto,
+    }: {
+      patientUserId: string;
+      dto: CreateVaccinationApplicationDto;
+    }) => createVaccinationApplication(patientUserId, dto),
+    onSuccess: (_, variables) => {
+      invalidateVaccinationQueries(variables.patientUserId);
+    },
+  });
+
+  const updateApplicationMutation = useMutation({
+    mutationFn: ({
+      applicationId,
+      dto,
+    }: {
+      applicationId: string;
+      dto: UpdateVaccinationApplicationDto;
+    }) => updateVaccinationApplication(applicationId, dto),
+    onSuccess: (application) => {
+      invalidateVaccinationQueries(application.patientUserId);
+    },
+  });
+
+  const deleteApplicationMutation = useMutation({
+    mutationFn: ({ applicationId }: { applicationId: string }) =>
+      deleteVaccinationApplication(applicationId),
+    onSuccess: () => {
+      invalidateVaccinationQueries();
+    },
+  });
+
+  return {
+    createApplicationMutation,
+    updateApplicationMutation,
+    deleteApplicationMutation,
+  };
+};

--- a/src/pages/protected/My-Vaccination/page.tsx
+++ b/src/pages/protected/My-Vaccination/page.tsx
@@ -1,0 +1,68 @@
+import { Helmet } from "react-helmet-async";
+import { Loader2, Syringe } from "lucide-react";
+
+import { PageHeader } from "@/components/PageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { VaccinationCardView } from "@/components/Vaccination/VaccinationCardView";
+import { useMyVaccinationCard } from "@/hooks/Vaccination/useVaccinationCard";
+
+const MyVaccinationPage = () => {
+  const { vaccinationCard, isLoading, error } = useMyVaccinationCard();
+
+  const breadcrumbItems = [
+    { label: "Inicio", href: "/inicio" },
+    { label: "Mi carnet de vacunacion" },
+  ];
+
+  return (
+    <>
+      <Helmet>
+        <title>Mi carnet de vacunacion</title>
+        <meta
+          name="description"
+          content="Consulta tu carnet de vacunacion y pendientes por calendario."
+        />
+      </Helmet>
+
+      <div className="space-y-6 p-6">
+        <PageHeader
+          breadcrumbItems={breadcrumbItems}
+          title="Mi carnet de vacunacion"
+          description="Consulta vacunas aplicadas, pendientes y vencidas"
+          icon={<Syringe className="h-6 w-6" />}
+        />
+
+        {error && (
+          <Card className="border-red-200 bg-red-50">
+            <CardContent className="py-4">
+              <p className="text-red-600">
+                Hubo un error al cargar tu carnet de vacunacion.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {isLoading ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-green-600" />
+              <p className="text-gray-500">Cargando carnet...</p>
+            </CardContent>
+          </Card>
+        ) : vaccinationCard ? (
+          <VaccinationCardView vaccinationCard={vaccinationCard} />
+        ) : (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <p className="text-gray-500">
+                No hay carnet de vacunacion disponible.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default MyVaccinationPage;

--- a/src/pages/protected/Patient/Dashboard/index.tsx
+++ b/src/pages/protected/Patient/Dashboard/index.tsx
@@ -39,6 +39,10 @@ export default function PatientDashboard({ patient }: { patient: Patient }) {
     navigate(`/pacientes/${patient.slug}/carton-verde`);
   };
 
+  const handleVacunacionClick = () => {
+    navigate(`/pacientes/${patient.slug}/vacunacion`);
+  };
+
   return (
     <div className="space-y-6">
       {/* Header del Paciente */}
@@ -59,6 +63,7 @@ export default function PatientDashboard({ patient }: { patient: Patient }) {
         onCitasMedicasClick={handleCitasMedicasClick}
         onChequeosPeriodicosClick={handleChequeosPeriodicosClick}
         onCartonVerdeClick={handleCartonVerdeClick}
+        onVacunacionClick={handleVacunacionClick}
         totalStudies={stats.totalStudies}
       />
     </div>

--- a/src/pages/protected/Patient/Vaccination/index.tsx
+++ b/src/pages/protected/Patient/Vaccination/index.tsx
@@ -1,0 +1,132 @@
+import { Helmet } from "react-helmet-async";
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, Loader2, Syringe } from "lucide-react";
+
+import { PageHeader } from "@/components/PageHeader";
+import { PatientCardSkeleton } from "@/components/Skeleton/Patient";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { VaccinationCardView } from "@/components/Vaccination/VaccinationCardView";
+import { usePatient } from "@/hooks/Patient/usePatient";
+import { usePatientVaccinationCard } from "@/hooks/Vaccination/useVaccinationCard";
+
+const PatientVaccinationPage = () => {
+  const params = useParams();
+  const slug = params.slug;
+  const slugString = slug as string;
+  const slugParts = slugString.split("-");
+  const id = slugParts[slugParts.length - 1];
+
+  const {
+    patient,
+    isLoading: isLoadingPatient,
+    error: patientError,
+  } = usePatient({
+    auth: true,
+    id,
+  });
+
+  const {
+    vaccinationCard,
+    isLoading: isLoadingCard,
+    error: cardError,
+  } = usePatientVaccinationCard({
+    patientUserId: patient?.id || "",
+    enabled: Boolean(patient?.id),
+  });
+
+  const isFirstLoadingPatient = isLoadingPatient && !patient;
+  const patientName = patient
+    ? `${patient.firstName} ${patient.lastName}`
+    : "Paciente";
+
+  const breadcrumbItems = [
+    { label: "Inicio", href: "/inicio" },
+    { label: "Pacientes", href: "/pacientes" },
+    {
+      label: patientName,
+      href: `/pacientes/${slug}`,
+    },
+    { label: "Vacunacion" },
+  ];
+
+  if (isFirstLoadingPatient) {
+    return (
+      <div className="space-y-4 p-6">
+        <div className="gap-6 md:grid md:grid-cols-[320px_1fr]">
+          <PatientCardSkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>{`${patientName} - Carnet de vacunacion`}</title>
+        <meta
+          name="description"
+          content={`Carnet de vacunacion del paciente ${patient?.firstName}.`}
+        />
+      </Helmet>
+
+      <div className="space-y-6 p-6">
+        <PageHeader
+          breadcrumbItems={breadcrumbItems}
+          title={`Vacunacion - ${patientName}`}
+          description="Consulta pendientes y registra vacunas aplicadas"
+          icon={<Syringe className="h-6 w-6" />}
+          actions={
+            <Link to={`/pacientes/${slug}`}>
+              <Button variant="outline" className="shadow-sm">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Volver
+              </Button>
+            </Link>
+          }
+        />
+
+        {patientError && (
+          <Card className="border-red-200 bg-red-50">
+            <CardContent className="py-4">
+              <p className="text-red-600">
+                Hubo un error al cargar los datos del paciente.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {cardError && (
+          <Card className="border-red-200 bg-red-50">
+            <CardContent className="py-4">
+              <p className="text-red-600">
+                Hubo un error al cargar el carnet de vacunacion.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        {isLoadingCard ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-green-600" />
+              <p className="text-gray-500">Cargando carnet...</p>
+            </CardContent>
+          </Card>
+        ) : vaccinationCard ? (
+          <VaccinationCardView vaccinationCard={vaccinationCard} isDoctor />
+        ) : (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <p className="text-gray-500">
+                No hay carnet de vacunacion disponible para este paciente.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default PatientVaccinationPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -69,8 +69,10 @@ import AuditPage from "./pages/protected/Audit";
 import SettingsPage from "./pages/protected/Settings";
 import MyPrescriptionRequestsPage from "./pages/protected/My-Prescription-Requests/page";
 import MyCheckupsPage from "./pages/protected/My-Checkups/page";
+import MyVaccinationPage from "./pages/protected/My-Vaccination/page";
 import DoctorPrescriptionRequestsPage from "./pages/protected/Doctor-Prescription-Requests/page";
 import PatientGreenCardPage from "./pages/protected/Patient/Green-Card";
+import PatientVaccinationPage from "./pages/protected/Patient/Vaccination";
 import DoctorServicesPage from "./pages/protected/Admin/Doctor-Services";
 import HolidaysPage from "./pages/protected/Admin/Holidays";
 import AppointmentsReportsPage from "./pages/protected/Admin/Appointments-Reports";
@@ -296,6 +298,14 @@ const router = createBrowserRouter(
               </Private_Routes>
             }
           />
+          <Route
+            path="/mis-vacunas"
+            element={
+              <Private_Routes allowedRoles={["Paciente"]}>
+                <MyVaccinationPage />
+              </Private_Routes>
+            }
+          />
 
           {/* Solicitudes de Recetas - Médico */}
           <Route
@@ -419,6 +429,14 @@ const router = createBrowserRouter(
             element={
               <Private_Routes allowedRoles={["Medico"]}>
                 <PatientGreenCardPage />
+              </Private_Routes>
+            }
+          />
+          <Route
+            path="/pacientes/:slug/vacunacion"
+            element={
+              <Private_Routes allowedRoles={["Medico"]}>
+                <PatientVaccinationPage />
               </Private_Routes>
             }
           />

--- a/src/types/Vaccination/Vaccination.ts
+++ b/src/types/Vaccination/Vaccination.ts
@@ -1,0 +1,104 @@
+export type VaccinationCardStatus =
+  | "applied"
+  | "pending"
+  | "overdue"
+  | "upcoming";
+
+export interface VaccinationVaccine {
+  id: string;
+  code: string;
+  name: string;
+  description?: string;
+  source?: string;
+  active: boolean;
+}
+
+export interface VaccinationScheduleRule {
+  id: string;
+  vaccineId: string;
+  vaccine?: VaccinationVaccine;
+  doseLabel: string;
+  recommendedAgeMonths?: number | null;
+  overdueAgeMonths?: number | null;
+  sortOrder: number;
+  notes?: string;
+  active: boolean;
+}
+
+export interface VaccinationDoctorInfo {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface VaccinationPatientInfo {
+  id: string;
+  firstName: string;
+  lastName: string;
+  userName: string;
+  birthDate: string;
+}
+
+export interface VaccinationApplication {
+  id: string;
+  patientUserId: string;
+  vaccineId: string;
+  scheduleRuleId: string;
+  doseLabel: string;
+  appliedDate: string;
+  observations?: string;
+  doctorUserId: string;
+  doctor?: VaccinationDoctorInfo;
+  vaccine?: VaccinationVaccine;
+  canEdit: boolean;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+export interface VaccinationCardItem {
+  scheduleRuleId: string;
+  vaccineId: string;
+  vaccine: VaccinationVaccine;
+  doseLabel: string;
+  recommendedAgeMonths?: number | null;
+  overdueAgeMonths?: number | null;
+  recommendedDate?: string;
+  overdueDate?: string;
+  status: VaccinationCardStatus;
+  notes?: string;
+  application?: VaccinationApplication;
+}
+
+export interface VaccinationCardCounts {
+  applied: number;
+  pending: number;
+  overdue: number;
+  upcoming: number;
+}
+
+export interface VaccinationCard {
+  patientUserId: string;
+  patient?: VaccinationPatientInfo;
+  generatedAt: string;
+  counts: VaccinationCardCounts;
+  items: VaccinationCardItem[];
+  applications: VaccinationApplication[];
+  canAddApplications: boolean;
+}
+
+export interface VaccinationCatalog {
+  vaccines: VaccinationVaccine[];
+  scheduleRules: VaccinationScheduleRule[];
+}
+
+export interface CreateVaccinationApplicationDto {
+  scheduleRuleId: string;
+  appliedDate: string;
+  observations?: string;
+}
+
+export interface UpdateVaccinationApplicationDto {
+  scheduleRuleId?: string;
+  appliedDate?: string;
+  observations?: string;
+}

--- a/src/validators/vaccination.schema.test.ts
+++ b/src/validators/vaccination.schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { VaccinationApplicationSchema } from "./vaccination.schema";
+
+describe("VaccinationApplicationSchema", () => {
+  it("requires a schedule rule and application date", () => {
+    const result = VaccinationApplicationSchema.safeParse({
+      scheduleRuleId: "",
+      appliedDate: "",
+      observations: "Control",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.scheduleRuleId).toContain(
+        "Selecciona una vacuna y dosis"
+      );
+      expect(result.error.flatten().fieldErrors.appliedDate).toContain(
+        "La fecha de aplicacion es requerida"
+      );
+    }
+  });
+
+  it("accepts a controlled dose with an optional observation", () => {
+    const result = VaccinationApplicationSchema.safeParse({
+      scheduleRuleId: "rule-uuid",
+      appliedDate: "2026-05-13",
+      observations: "Sin reacciones",
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/validators/vaccination.schema.ts
+++ b/src/validators/vaccination.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const VaccinationApplicationSchema = z.object({
+  scheduleRuleId: z.string().min(1, "Selecciona una vacuna y dosis"),
+  appliedDate: z.string().min(1, "La fecha de aplicacion es requerida"),
+  observations: z.string().optional(),
+});
+
+export type VaccinationApplicationFormValues = z.infer<
+  typeof VaccinationApplicationSchema
+>;


### PR DESCRIPTION
Summary:
- Adds patient and doctor vaccination card routes in the portal.
- Adds read-only patient view and editable doctor view with controlled catalog selection.
- Shows applied, pending, overdue and upcoming states with focused tests.

Testing:
- npm run type-check
- npm run build
- npm run lint
- npm run test:run