### PR TITLE
fix: alinear eventos socket conversaciones con backend himalaya

### DIFF
--- a/src/api/Conversations/conversations.api.test.ts
+++ b/src/api/Conversations/conversations.api.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+import { apiConversations } from "@/services/axiosConfig";
+import { sendConversationMedia } from "./conversations.api";
+
+vi.mock("@/config/environment", () => ({
+  environment: {
+    CONVERSATIONS_MOCK: false,
+  },
+}));
+
+vi.mock("@/services/axiosConfig", () => ({
+  apiConversations: {
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+describe("sendConversationMedia", () => {
+  it("sends files as multipart form-data without base64 encoding", async () => {
+    const file = new File(["orden"], "orden.pdf", {
+      type: "application/pdf",
+    });
+
+    await sendConversationMedia("conv-1", file, "  Te mando la orden.  ");
+
+    expect(apiConversations.post).toHaveBeenCalledWith(
+      "/conversations/conv-1/media",
+      expect.any(FormData),
+    );
+    const formData = vi.mocked(apiConversations.post).mock.calls[0][1] as FormData;
+    expect(formData.get("file")).toBe(file);
+    expect(formData.get("caption")).toBe("Te mando la orden.");
+  });
+});

--- a/src/api/Conversations/conversations.api.ts
+++ b/src/api/Conversations/conversations.api.ts
@@ -89,19 +89,6 @@ export async function sendMessage(
   return data;
 }
 
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error("No se pudo leer el archivo"));
-    reader.onload = () => {
-      const result = String(reader.result);
-      const comma = result.indexOf(",");
-      resolve(comma >= 0 ? result.slice(comma + 1) : result);
-    };
-    reader.readAsDataURL(file);
-  });
-}
-
 export async function sendConversationMedia(
   id: string,
   file: File,
@@ -110,13 +97,13 @@ export async function sendConversationMedia(
   if (environment.CONVERSATIONS_MOCK) {
     throw new Error("Adjuntar archivos no está disponible en modo demo");
   }
-  const dataBase64 = await fileToBase64(file);
-  await apiConversations.post(`/conversations/${id}/media`, {
-    mimeType: file.type || "application/octet-stream",
-    filename: file.name,
-    dataBase64,
-    caption: caption?.trim() || undefined,
-  });
+  const formData = new FormData();
+  formData.append("file", file);
+  const trimmedCaption = caption?.trim();
+  if (trimmedCaption) {
+    formData.append("caption", trimmedCaption);
+  }
+  await apiConversations.post(`/conversations/${id}/media`, formData);
 }
 
 export async function markConversationRead(id: string): Promise<void> {

--- a/src/api/Conversations/conversations.api.ts
+++ b/src/api/Conversations/conversations.api.ts
@@ -64,6 +64,17 @@ export async function getMessages(
   return data;
 }
 
+export async function getMessageMedia(
+  conversationId: string,
+  messageId: string,
+): Promise<Blob> {
+  const { data } = await apiConversations.get<Blob>(
+    `/conversations/${conversationId}/messages/${messageId}/media`,
+    { responseType: "blob" },
+  );
+  return data;
+}
+
 export async function sendMessage(
   id: string,
   input: SendConversationMessageInput,

--- a/src/api/Conversations/conversations.api.ts
+++ b/src/api/Conversations/conversations.api.ts
@@ -89,6 +89,11 @@ export async function sendMessage(
   return data;
 }
 
+export async function markConversationRead(id: string): Promise<void> {
+  if (environment.CONVERSATIONS_MOCK) return;
+  await apiConversations.post(`/conversations/${id}/read`);
+}
+
 export async function takeConversation(id: string): Promise<Conversation> {
   const { data } = await apiConversations.post<Conversation>(
     `/conversations/${id}/take`,

--- a/src/api/Conversations/conversations.api.ts
+++ b/src/api/Conversations/conversations.api.ts
@@ -89,6 +89,36 @@ export async function sendMessage(
   return data;
 }
 
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("No se pudo leer el archivo"));
+    reader.onload = () => {
+      const result = String(reader.result);
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function sendConversationMedia(
+  id: string,
+  file: File,
+  caption?: string,
+): Promise<void> {
+  if (environment.CONVERSATIONS_MOCK) {
+    throw new Error("Adjuntar archivos no está disponible en modo demo");
+  }
+  const dataBase64 = await fileToBase64(file);
+  await apiConversations.post(`/conversations/${id}/media`, {
+    mimeType: file.type || "application/octet-stream",
+    filename: file.name,
+    dataBase64,
+    caption: caption?.trim() || undefined,
+  });
+}
+
 export async function markConversationRead(id: string): Promise<void> {
   if (environment.CONVERSATIONS_MOCK) return;
   await apiConversations.post(`/conversations/${id}/read`);

--- a/src/components/Conversations/MessageComposer.test.tsx
+++ b/src/components/Conversations/MessageComposer.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MessageComposer } from ".";
+
+describe("MessageComposer", () => {
+  it("keeps the selected file and caption when media sending fails", async () => {
+    const onSend = vi.fn();
+    const onSendMedia = vi.fn().mockRejectedValue(new Error("send failed"));
+    const { container } = render(
+      <MessageComposer
+        disabled={false}
+        onSend={onSend}
+        onSendMedia={onSendMedia}
+      />,
+    );
+
+    selectFile(container, new File(["orden"], "orden.pdf", {
+      type: "application/pdf",
+    }));
+    fireEvent.change(screen.getByPlaceholderText(/comentario/i), {
+      target: { value: "Te mando la orden." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /enviar mensaje/i }));
+
+    await waitFor(() => expect(onSendMedia).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /enviar mensaje/i }))
+        .not.toBeDisabled(),
+    );
+
+    expect(screen.getByText("orden.pdf")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Te mando la orden.")).toBeInTheDocument();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("clears the selected file and caption after media sending succeeds", async () => {
+    const onSendMedia = vi.fn().mockResolvedValue(undefined);
+    const { container } = render(
+      <MessageComposer
+        disabled={false}
+        onSend={vi.fn()}
+        onSendMedia={onSendMedia}
+      />,
+    );
+
+    selectFile(container, new File(["orden"], "orden.pdf", {
+      type: "application/pdf",
+    }));
+    fireEvent.change(screen.getByPlaceholderText(/comentario/i), {
+      target: { value: "Te mando la orden." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /enviar mensaje/i }));
+
+    await waitFor(() => expect(onSendMedia).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.queryByText("orden.pdf")).not.toBeInTheDocument(),
+    );
+
+    expect(screen.getByRole("textbox")).toHaveValue("");
+  });
+});
+
+function selectFile(container: HTMLElement, file: File): void {
+  const input = container.querySelector<HTMLInputElement>("input[type='file']");
+  if (!input) throw new Error("file input not found");
+  fireEvent.change(input, { target: { files: [file] } });
+}

--- a/src/components/Conversations/index.tsx
+++ b/src/components/Conversations/index.tsx
@@ -511,8 +511,8 @@ export function ConversationDetailView({
             mutations.sendMessage.isPending ||
             mutations.sendMedia.isPending
           }
-          onSend={(content) => mutations.sendMessage.mutate({ content })}
-          onSendMedia={(input) => mutations.sendMedia.mutate(input)}
+          onSend={(content) => mutations.sendMessage.mutateAsync({ content })}
+          onSendMedia={(input) => mutations.sendMedia.mutateAsync(input)}
         />
       </div>
       <PatientContextSheet
@@ -976,8 +976,8 @@ const MAX_ATTACHMENT_BYTES = 16 * 1024 * 1024;
 
 interface MessageComposerProps {
   disabled: boolean;
-  onSend: (content: string) => void;
-  onSendMedia: (input: { file: File; caption?: string }) => void;
+  onSend: (content: string) => Promise<unknown> | unknown;
+  onSendMedia: (input: { file: File; caption?: string }) => Promise<unknown> | unknown;
 }
 
 export function MessageComposer({
@@ -987,9 +987,10 @@ export function MessageComposer({
 }: MessageComposerProps) {
   const [content, setContent] = useState("");
   const [file, setFile] = useState<File | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const trimmed = content.trim();
-  const canSubmit = !disabled && (!!file || !!trimmed);
+  const canSubmit = !disabled && !isSubmitting && (!!file || !!trimmed);
 
   const reset = () => {
     setContent("");
@@ -997,20 +998,27 @@ export function MessageComposer({
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
-  const submit = () => {
+  const submit = async () => {
     if (!canSubmit) return;
-    if (file) {
-      onSendMedia({ file, caption: trimmed || undefined });
-    } else {
-      onSend(trimmed);
+    setIsSubmitting(true);
+    try {
+      if (file) {
+        await onSendMedia({ file, caption: trimmed || undefined });
+      } else {
+        await onSend(trimmed);
+      }
+      reset();
+    } catch {
+      // El hook de mutación muestra el error. Mantener el borrador evita perder el adjunto.
+    } finally {
+      setIsSubmitting(false);
     }
-    reset();
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      submit();
+      void submit();
     }
   };
 
@@ -1035,6 +1043,7 @@ export function MessageComposer({
           </span>
           <button
             type="button"
+            disabled={isSubmitting}
             onClick={() => {
               setFile(null);
               if (fileInputRef.current) fileInputRef.current.value = "";
@@ -1057,7 +1066,7 @@ export function MessageComposer({
           size="icon"
           variant="ghost"
           onClick={() => fileInputRef.current?.click()}
-          disabled={disabled}
+          disabled={disabled || isSubmitting}
           aria-label="Adjuntar archivo"
           className="h-11 w-11 shrink-0 rounded-full text-gray-500 hover:bg-gray-200"
         >
@@ -1068,7 +1077,7 @@ export function MessageComposer({
             value={content}
             onChange={(event) => setContent(event.target.value)}
             onKeyDown={handleKeyDown}
-            disabled={disabled}
+            disabled={disabled || isSubmitting}
             placeholder={
               disabled
                 ? "Conversación cerrada"
@@ -1081,7 +1090,7 @@ export function MessageComposer({
         </div>
         <Button
           size="icon"
-          onClick={submit}
+          onClick={() => void submit()}
           disabled={!canSubmit}
           aria-label="Enviar mensaje"
           className="h-11 w-11 shrink-0 rounded-full bg-greenPrimary hover:bg-greenSecondary disabled:bg-gray-300"

--- a/src/components/Conversations/index.tsx
+++ b/src/components/Conversations/index.tsx
@@ -77,6 +77,7 @@ import {
 } from "@/types/Conversations";
 import { useConversationMutations } from "@/hooks/Conversations/useConversationMutations";
 import { useConversationTabCounts } from "@/hooks/Conversations/useConversationTabCounts";
+import { getMessageMedia } from "@/api/Conversations/conversations.api";
 
 /* -------------------------------------------------------------------------- */
 /*  Estilo base tipo WhatsApp Web con marca INCOR (#187B80)                    */
@@ -799,6 +800,89 @@ interface MessageBubbleProps {
   lastOfGroup?: boolean;
 }
 
+function isMediaPlaceholder(message: ConversationMessage): boolean {
+  return (
+    !!message.mediaUrl &&
+    /^\[(image|document|audio|video|sticker)\]$/i.test(
+      message.content.trim(),
+    )
+  );
+}
+
+function MediaAttachment({ message }: { message: ConversationMessage }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const type = (message.mediaType ?? "").toLowerCase();
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setUrl(null);
+    setFailed(false);
+    getMessageMedia(message.conversationId, message.id)
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [message.conversationId, message.id]);
+
+  if (failed) {
+    return (
+      <div className="mb-1 rounded-lg bg-black/5 px-3 py-2 text-[12px] text-gray-500">
+        No se pudo cargar el adjunto
+      </div>
+    );
+  }
+  if (!url) {
+    return (
+      <div className="mb-1 h-40 w-56 max-w-full animate-pulse rounded-lg bg-black/5" />
+    );
+  }
+  if (type === "image" || type === "sticker") {
+    return (
+      <a href={url} target="_blank" rel="noreferrer" className="block">
+        <img
+          src={url}
+          alt="Adjunto"
+          className="mb-1 max-h-72 w-auto max-w-full rounded-lg object-cover"
+        />
+      </a>
+    );
+  }
+  if (type === "audio") {
+    return <audio controls src={url} className="mb-1 w-60 max-w-full" />;
+  }
+  if (type === "video") {
+    return (
+      <video
+        controls
+        src={url}
+        className="mb-1 max-h-72 w-auto max-w-full rounded-lg"
+      />
+    );
+  }
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      download
+      className="mb-1 inline-flex items-center gap-2 rounded-lg bg-black/5 px-3 py-2 text-[13px] font-medium text-greenSecondary hover:bg-black/10"
+    >
+      <FileText className="h-4 w-4" />
+      Abrir adjunto
+    </a>
+  );
+}
+
 export function MessageBubble({
   message,
   firstOfGroup = true,
@@ -848,9 +932,12 @@ export function MessageBubble({
             {senderLabel}
           </div>
         )}
-        <p className="whitespace-pre-wrap break-words text-[14px] leading-[19px]">
-          {message.content}
-        </p>
+        {message.mediaUrl && <MediaAttachment message={message} />}
+        {!isMediaPlaceholder(message) && (
+          <p className="whitespace-pre-wrap break-words text-[14px] leading-[19px]">
+            {message.content}
+          </p>
+        )}
         <div className="float-right ml-2 mt-1 flex translate-y-0.5 items-center gap-1 text-[10px] text-gray-400">
           <span>{formatTime(message.createdAt)}</span>
           {!inbound && <DeliveryStatus status={message.status} />}

--- a/src/components/Conversations/index.tsx
+++ b/src/components/Conversations/index.tsx
@@ -1,4 +1,5 @@
 import {
+  ChangeEvent,
   CSSProperties,
   KeyboardEvent,
   useCallback,
@@ -21,10 +22,12 @@ import {
   Lock,
   MoreHorizontal,
   MessageCircle,
+  Paperclip,
   Phone,
   RefreshCcw,
   Search,
   Send,
+  X,
   StickyNote,
   Tag,
   UserRound,
@@ -78,6 +81,7 @@ import {
 import { useConversationMutations } from "@/hooks/Conversations/useConversationMutations";
 import { useConversationTabCounts } from "@/hooks/Conversations/useConversationTabCounts";
 import { getMessageMedia } from "@/api/Conversations/conversations.api";
+import { toast } from "sonner";
 
 /* -------------------------------------------------------------------------- */
 /*  Estilo base tipo WhatsApp Web con marca INCOR (#187B80)                    */
@@ -502,8 +506,13 @@ export function ConversationDetailView({
         />
         <MessageThread messages={detail.messages} />
         <MessageComposer
-          disabled={!canRespond || mutations.sendMessage.isPending}
+          disabled={
+            !canRespond ||
+            mutations.sendMessage.isPending ||
+            mutations.sendMedia.isPending
+          }
           onSend={(content) => mutations.sendMessage.mutate({ content })}
+          onSendMedia={(input) => mutations.sendMedia.mutate(input)}
         />
       </div>
       <PatientContextSheet
@@ -963,19 +972,39 @@ function DeliveryStatus({ status }: { status: MessageStatus }) {
   return <Check className="h-3.5 w-3.5 text-gray-400" />;
 }
 
+const MAX_ATTACHMENT_BYTES = 16 * 1024 * 1024;
+
 interface MessageComposerProps {
   disabled: boolean;
   onSend: (content: string) => void;
+  onSendMedia: (input: { file: File; caption?: string }) => void;
 }
 
-export function MessageComposer({ disabled, onSend }: MessageComposerProps) {
+export function MessageComposer({
+  disabled,
+  onSend,
+  onSendMedia,
+}: MessageComposerProps) {
   const [content, setContent] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const trimmed = content.trim();
+  const canSubmit = !disabled && (!!file || !!trimmed);
+
+  const reset = () => {
+    setContent("");
+    setFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
 
   const submit = () => {
-    if (!trimmed || disabled) return;
-    onSend(trimmed);
-    setContent("");
+    if (!canSubmit) return;
+    if (file) {
+      onSendMedia({ file, caption: trimmed || undefined });
+    } else {
+      onSend(trimmed);
+    }
+    reset();
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -985,9 +1014,55 @@ export function MessageComposer({ disabled, onSend }: MessageComposerProps) {
     }
   };
 
+  const handleFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0];
+    if (!selected) return;
+    if (selected.size > MAX_ATTACHMENT_BYTES) {
+      toast.error("El archivo supera el límite de 16 MB");
+      event.target.value = "";
+      return;
+    }
+    setFile(selected);
+  };
+
   return (
     <div className="border-t border-gray-200 bg-[#f0f2f1] px-4 py-3">
+      {file && (
+        <div className="mb-2 flex items-center gap-2 rounded-lg bg-white px-3 py-2 text-sm shadow-sm">
+          <Paperclip className="h-4 w-4 shrink-0 text-greenPrimary" />
+          <span className="min-w-0 flex-1 truncate text-gray-700">
+            {file.name}
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              setFile(null);
+              if (fileInputRef.current) fileInputRef.current.value = "";
+            }}
+            aria-label="Quitar adjunto"
+            className="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
       <div className="flex items-end gap-2">
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          onChange={handleFile}
+        />
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
+          aria-label="Adjuntar archivo"
+          className="h-11 w-11 shrink-0 rounded-full text-gray-500 hover:bg-gray-200"
+        >
+          <Paperclip className="h-5 w-5" />
+        </Button>
         <div className="flex-1 rounded-3xl bg-white shadow-sm">
           <Textarea
             value={content}
@@ -997,7 +1072,9 @@ export function MessageComposer({ disabled, onSend }: MessageComposerProps) {
             placeholder={
               disabled
                 ? "Conversación cerrada"
-                : "Escribí un mensaje  ·  Enter para enviar, Shift+Enter para salto de línea"
+                : file
+                  ? "Agregá un comentario (opcional)"
+                  : "Escribí un mensaje  ·  Enter para enviar, Shift+Enter para salto de línea"
             }
             className="max-h-40 min-h-[44px] resize-none border-0 bg-transparent px-4 py-3 text-sm shadow-none focus-visible:ring-0"
           />
@@ -1005,7 +1082,7 @@ export function MessageComposer({ disabled, onSend }: MessageComposerProps) {
         <Button
           size="icon"
           onClick={submit}
-          disabled={!trimmed || disabled}
+          disabled={!canSubmit}
           aria-label="Enviar mensaje"
           className="h-11 w-11 shrink-0 rounded-full bg-greenPrimary hover:bg-greenSecondary disabled:bg-gray-300"
         >

--- a/src/hooks/Conversations/useConversationMutations.ts
+++ b/src/hooks/Conversations/useConversationMutations.ts
@@ -7,6 +7,7 @@ import {
   conversationKeys,
   reopenConversation,
   rerouteConversation,
+  sendConversationMedia,
   sendMessage,
   takeConversation,
   updateTags,
@@ -30,6 +31,20 @@ export function useConversationMutations(conversationId: string | null) {
       onError: (error: unknown) => {
         toast.error(
           extractErrorMessage(error, "No se pudo enviar el mensaje"),
+        );
+      },
+    }),
+    sendMedia: useMutation({
+      mutationFn: (input: { file: File; caption?: string }) =>
+        sendConversationMedia(
+          requireId(conversationId),
+          input.file,
+          input.caption,
+        ),
+      onSuccess: invalidate,
+      onError: (error: unknown) => {
+        toast.error(
+          extractErrorMessage(error, "No se pudo enviar el adjunto"),
         );
       },
     }),

--- a/src/hooks/Conversations/useConversationMutations.ts
+++ b/src/hooks/Conversations/useConversationMutations.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { toast } from "sonner";
 import {
   addInternalNote,
   closeConversation,
@@ -25,6 +27,11 @@ export function useConversationMutations(conversationId: string | null) {
       mutationFn: (input: SendConversationMessageInput) =>
         sendMessage(requireId(conversationId), input),
       onSuccess: invalidate,
+      onError: (error: unknown) => {
+        toast.error(
+          extractErrorMessage(error, "No se pudo enviar el mensaje"),
+        );
+      },
     }),
     takeConversation: useMutation({
       mutationFn: () => takeConversation(requireId(conversationId)),
@@ -58,4 +65,16 @@ export function useConversationMutations(conversationId: string | null) {
 function requireId(id: string | null): string {
   if (!id) throw new Error("conversationId required");
   return id;
+}
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (isAxiosError(error)) {
+    const data = error.response?.data as
+      | { message?: string | string[] }
+      | undefined;
+    const message = data?.message;
+    if (Array.isArray(message)) return message.join(", ");
+    if (typeof message === "string") return message;
+  }
+  return fallback;
 }

--- a/src/hooks/Conversations/useConversationNotifications.ts
+++ b/src/hooks/Conversations/useConversationNotifications.ts
@@ -236,12 +236,12 @@ export function useConversationNotifications(
     if (!socketEnabled) return undefined;
 
     const socket = connectConversationsSocket();
-    socket.on(ConversationSocketEvents.MESSAGE_CREATED, handleIncoming);
+    socket.on(ConversationSocketEvents.MESSAGE_RECEIVED, handleIncoming);
     socket.on(ConversationSocketEvents.CREATED, handleIncoming);
     socket.on(ConversationSocketEvents.ESCALATED, handleIncoming);
 
     return () => {
-      socket.off(ConversationSocketEvents.MESSAGE_CREATED, handleIncoming);
+      socket.off(ConversationSocketEvents.MESSAGE_RECEIVED, handleIncoming);
       socket.off(ConversationSocketEvents.CREATED, handleIncoming);
       socket.off(ConversationSocketEvents.ESCALATED, handleIncoming);
       if (timerRef.current) {

--- a/src/hooks/Conversations/useConversationSocket.ts
+++ b/src/hooks/Conversations/useConversationSocket.ts
@@ -24,7 +24,8 @@ export function useConversationSocket(conversationId: string | null) {
     socket.on(ConversationSocketEvents.ASSIGNED, invalidateAll);
     socket.on(ConversationSocketEvents.CLOSED, invalidateAll);
     socket.on(ConversationSocketEvents.REROUTED, invalidateAll);
-    socket.on(ConversationSocketEvents.MESSAGE_CREATED, invalidateAll);
+    socket.on(ConversationSocketEvents.MESSAGE_RECEIVED, invalidateAll);
+    socket.on(ConversationSocketEvents.MESSAGE_SENT, invalidateAll);
     socket.on(ConversationSocketEvents.STATUS_UPDATED, invalidateAll);
     socket.on("connect", invalidateAll);
 
@@ -35,7 +36,8 @@ export function useConversationSocket(conversationId: string | null) {
       socket.off(ConversationSocketEvents.ASSIGNED, invalidateAll);
       socket.off(ConversationSocketEvents.CLOSED, invalidateAll);
       socket.off(ConversationSocketEvents.REROUTED, invalidateAll);
-      socket.off(ConversationSocketEvents.MESSAGE_CREATED, invalidateAll);
+      socket.off(ConversationSocketEvents.MESSAGE_RECEIVED, invalidateAll);
+      socket.off(ConversationSocketEvents.MESSAGE_SENT, invalidateAll);
       socket.off(ConversationSocketEvents.STATUS_UPDATED, invalidateAll);
       socket.off("connect", invalidateAll);
     };

--- a/src/pages/protected/Conversations/index.tsx
+++ b/src/pages/protected/Conversations/index.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
 import { MessageCircle, RefreshCcw } from "lucide-react";
+import {
+  conversationKeys,
+  markConversationRead,
+} from "@/api/Conversations/conversations.api";
 import {
   ConversationDetailView,
   ConversationsInbox,
@@ -41,8 +46,25 @@ export default function ConversationsPage({
   }, [conversationsQuery.data?.items]);
   const detailQuery = useConversationDetail(selectedId);
   const mutations = useConversationMutations(selectedId);
+  const queryClient = useQueryClient();
 
   useConversationSocket(selectedId);
+
+  const isUnread = detailQuery.data?.unread ?? false;
+  useEffect(() => {
+    if (!selectedId || !isUnread) return;
+    let cancelled = false;
+    markConversationRead(selectedId)
+      .then(() => {
+        if (!cancelled) {
+          queryClient.invalidateQueries({ queryKey: conversationKeys.all });
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, isUnread, queryClient]);
 
   useEffect(() => {
     if (conversations.length === 0) {

--- a/src/services/conversations-socket.config.ts
+++ b/src/services/conversations-socket.config.ts
@@ -11,8 +11,9 @@ export enum ConversationSocketEvents {
   ASSIGNED = "conversation.assigned",
   CLOSED = "conversation.closed",
   REROUTED = "conversation.rerouted",
-  MESSAGE_CREATED = "message.created",
-  STATUS_UPDATED = "message.status.updated",
+  MESSAGE_RECEIVED = "message.received",
+  MESSAGE_SENT = "message.sent",
+  STATUS_UPDATED = "message.status_changed",
   SUBSCRIBE = "subscribe.conversation",
   UNSUBSCRIBE = "unsubscribe.conversation",
 }

--- a/src/types/Conversations/index.ts
+++ b/src/types/Conversations/index.ts
@@ -28,6 +28,7 @@ export interface ConversationMessage {
   senderName: string | null;
   content: string;
   mediaUrl: string | null;
+  mediaType?: string | null;
   status: MessageStatus;
   createdAt: string;
 }


### PR DESCRIPTION
## Resumen
El front escuchaba `message.created` y `message.status.updated`, pero el backend de himalaya emite `message.received`, `message.sent` y `message.status_changed`. Por eso el panel no recibía mensajes nuevos ni el estado de visto en tiempo real, ni disparaba las notificaciones (toast/sonido/badge) salvo por el polling de respaldo.

## Cambios
- `conversations-socket.config.ts`: `MESSAGE_RECEIVED`, `MESSAGE_SENT`, `STATUS_UPDATED=message.status_changed`
- `useConversationSocket`: suscribe a received + sent + status_changed
- `useConversationNotifications`: notifica con `message.received` (entrante)

## Test plan
- type-check + lint + build OK
- Con backend real: enviar mensaje desde WhatsApp y verificar que el panel refresca en vivo, suena y aparece el toast; verificar que el ✓✓ pasa a celeste al leer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)