### PR TITLE
fix: keep conversation identity visible

### DIFF
--- a/src/components/Conversations/ConversationIdentity.test.tsx
+++ b/src/components/Conversations/ConversationIdentity.test.tsx
@@ -7,31 +7,53 @@ import { ConversationListItem } from ".";
 import { getConversationDisplayIdentity } from "./conversation-identity";
 
 describe("conversation identity display", () => {
-  it("prioritizes the WhatsApp profile name and keeps clinical context", () => {
+  it("prioritizes the identified patient name and keeps WhatsApp context", () => {
     const identity = getConversationDisplayIdentity(conversation);
 
-    expect(identity.displayName).toBe("Marta WhatsApp");
-    expect(identity.listContext).toBe("Marta Benitez · DNI 24111222");
-    expect(identity.headerContext).toBe("Marta Benitez · DNI 24111222");
+    expect(identity.displayName).toBe("Marta Benitez");
+    expect(identity.listContext).toBe(
+      "WhatsApp: Marta WhatsApp · DNI 24111222 · +5493515550101",
+    );
+    expect(identity.headerContext).toBe(
+      "WhatsApp: Marta WhatsApp · DNI 24111222 · +5493515550101",
+    );
   });
 
   it("renders the WhatsApp avatar image when the API provides one", () => {
     render(
       <ConversationListItem
-        conversation={{
-          ...conversation,
-          profileImageUrl: "https://example.com/marta.jpg",
-        }}
+        conversation={withAvatar}
         selected={false}
         onSelect={vi.fn()}
       />,
     );
 
     expect(
-      screen.getByRole("img", { name: "Marta WhatsApp" }),
+      screen.getByRole("img", { name: "Marta Benitez" }),
     ).toHaveAttribute("src", "https://example.com/marta.jpg");
-    expect(screen.getByText("Marta WhatsApp")).toBeInTheDocument();
-    expect(screen.getByText("Marta Benitez · DNI 24111222")).toBeInTheDocument();
+    expect(screen.getByText("Marta Benitez")).toBeInTheDocument();
+    expect(
+      screen.getByText("WhatsApp: Marta WhatsApp · DNI 24111222 · +5493515550101"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to a visible phone when WhatsApp sends an invisible profile name", () => {
+    const identity = getConversationDisplayIdentity({
+      ...conversation,
+      profileName: "‎",
+      patient: {
+        ...conversation.patient,
+        patientId: null,
+        dni: null,
+        firstName: null,
+        lastName: null,
+        phone: "5493416113746",
+      },
+    });
+
+    expect(identity.displayName).toBe("+5493416113746");
+    expect(identity.whatsappName).toBeNull();
+    expect(identity.headerContext).toBe("Sin paciente identificado");
   });
 });
 
@@ -61,4 +83,9 @@ const conversation: Conversation = {
   unread: true,
   zammadTicketId: null,
   createdAt: "2026-05-22T14:45:00.000Z",
+};
+
+const withAvatar: Conversation = {
+  ...conversation,
+  profileImageUrl: "https://example.com/marta.jpg",
 };

--- a/src/components/Conversations/conversation-identity.ts
+++ b/src/components/Conversations/conversation-identity.ts
@@ -20,19 +20,24 @@ export function getConversationDisplayIdentity(
       .filter(Boolean)
       .join(" "),
   );
-  const phone = conversation.patient.phone;
-  const displayName = whatsappName ?? patientName ?? phone;
+  const phone = formatPhoneDisplay(conversation.patient.phone);
+  const displayName = patientName ?? whatsappName ?? phone;
   const sameVisibleName =
     !!whatsappName &&
     !!patientName &&
     whatsappName.toLocaleLowerCase("es-AR") ===
       patientName.toLocaleLowerCase("es-AR");
 
-  const clinicalParts = [
-    patientName && !sameVisibleName ? patientName : null,
-    conversation.patient.dni ? `DNI ${conversation.patient.dni}` : null,
+  const contextParts = [
+    patientName && whatsappName && !sameVisibleName
+      ? `WhatsApp: ${whatsappName}`
+      : null,
+    patientName && conversation.patient.dni
+      ? `DNI ${conversation.patient.dni}`
+      : null,
+    patientName || whatsappName ? phone : null,
   ].filter(Boolean) as string[];
-  const clinicalContext = clinicalParts.join(" · ");
+  const visibleContext = contextParts.join(" · ");
   const fallbackContext =
     displayName === phone ? "Sin paciente identificado" : phone;
 
@@ -42,13 +47,43 @@ export function getConversationDisplayIdentity(
     profileImageUrl: normalizeText(conversation.profileImageUrl),
     whatsappName,
     patientName,
-    listContext: clinicalContext || (whatsappName ? phone : null),
-    headerContext: clinicalContext || fallbackContext,
-    panelContext: clinicalContext || null,
+    listContext: visibleContext || null,
+    headerContext: visibleContext || fallbackContext,
+    panelContext: visibleContext || null,
   };
 }
 
 function normalizeText(value: string | null | undefined): string | null {
-  const normalized = value?.trim();
+  const normalized = value
+    ?.normalize("NFKC")
+    .split("")
+    .filter((character) => !isInvisibleProfileNameCharacter(character))
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
   return normalized || null;
+}
+
+function isInvisibleProfileNameCharacter(character: string): boolean {
+  const code = character.codePointAt(0) ?? 0;
+  return (
+    code <= 0x001f ||
+    (code >= 0x007f && code <= 0x009f) ||
+    code === 0x00ad ||
+    code === 0x061c ||
+    (code >= 0x200b && code <= 0x200f) ||
+    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2060 && code <= 0x206f) ||
+    code === 0xfeff
+  );
+}
+
+function formatPhoneDisplay(value: string | null | undefined): string {
+  const normalized = normalizeText(value);
+  if (!normalized) return "Contacto sin telefono";
+  if (normalized.startsWith("+")) return normalized;
+  const digitsOnly = normalized.replace(/\D/g, "");
+  return digitsOnly.length >= 8 && digitsOnly === normalized
+    ? `+${normalized}`
+    : normalized;
 }


### PR DESCRIPTION
Summary:\n- Changes identity priority to patient name, then visible WhatsApp name, then phone.\n- Strips invisible profile-name characters defensively in the frontend.\n- Adds coverage for patient identity and invisible WhatsApp profile-name fallback.\n\nLinked feature: INCOR 282, paired with backend feature 281.\n\nTests:\n- npm run lint\n- npm run type-check\n- npm test -- --run src/components/Conversations/ConversationIdentity.test.tsx src/components/Conversations/MediaAttachment.test.tsx src/components/Conversations/MessageComposer.test.tsx src/api/Conversations/conversations.api.test.ts src/hooks/Conversations/useConversationNotifications.test.ts\n- npm run build