### PR TITLE
feat: show declared contact name in conversations

### DIFF
--- a/src/api/Conversations/conversations.mock.ts
+++ b/src/api/Conversations/conversations.mock.ts
@@ -12,6 +12,7 @@ const mockConversations: ConversationDetail[] = [
   {
     id: "mock-1",
     profileName: "Marta WhatsApp",
+    contactDisplayName: null,
     profileImageUrl: null,
     patient: {
       patientId: 1482,
@@ -65,6 +66,7 @@ const mockConversations: ConversationDetail[] = [
   {
     id: "mock-2",
     profileName: "Roberto S.",
+    contactDisplayName: null,
     profileImageUrl: null,
     patient: {
       patientId: 2105,
@@ -113,11 +115,12 @@ const mockConversations: ConversationDetail[] = [
   },
   {
     id: "mock-3",
-    profileName: "Consulta turnos",
+    profileName: null,
+    contactDisplayName: "Marcos Pereira",
     profileImageUrl: null,
     patient: {
       patientId: null,
-      dni: null,
+      dni: "30111222",
       firstName: null,
       lastName: null,
       birthDate: null,

--- a/src/components/Conversations/ConversationIdentity.test.tsx
+++ b/src/components/Conversations/ConversationIdentity.test.tsx
@@ -41,6 +41,7 @@ describe("conversation identity display", () => {
     const identity = getConversationDisplayIdentity({
       ...conversation,
       profileName: "‎",
+      contactDisplayName: null,
       patient: {
         ...conversation.patient,
         patientId: null,
@@ -55,11 +56,45 @@ describe("conversation identity display", () => {
     expect(identity.whatsappName).toBeNull();
     expect(identity.headerContext).toBe("Sin paciente identificado");
   });
+
+  it("uses the declared contact name before WhatsApp and phone when there is no linked patient", () => {
+    const identity = getConversationDisplayIdentity({
+      ...conversation,
+      profileName: "‎",
+      contactDisplayName: "Martin Javier Vidal",
+      patient: {
+        ...conversation.patient,
+        patientId: null,
+        dni: "39121005",
+        firstName: null,
+        lastName: null,
+        phone: "5493416113746",
+      },
+    });
+
+    expect(identity.displayName).toBe("Martin Javier Vidal");
+    expect(identity.declaredContactName).toBe("Martin Javier Vidal");
+    expect(identity.listContext).toBe("DNI 39121005 · +5493416113746");
+    expect(identity.headerContext).toBe("DNI 39121005 · +5493416113746");
+  });
+
+  it("keeps the linked clinical patient as primary and shows the declared name as context", () => {
+    const identity = getConversationDisplayIdentity({
+      ...conversation,
+      contactDisplayName: "Marta B.",
+    });
+
+    expect(identity.displayName).toBe("Marta Benitez");
+    expect(identity.listContext).toBe(
+      "Declarado: Marta B. · WhatsApp: Marta WhatsApp · DNI 24111222 · +5493515550101",
+    );
+  });
 });
 
 const conversation: Conversation = {
   id: "conv-1",
   profileName: "Marta WhatsApp",
+  contactDisplayName: null,
   profileImageUrl: null,
   patient: {
     patientId: 1482,

--- a/src/components/Conversations/conversation-identity.ts
+++ b/src/components/Conversations/conversation-identity.ts
@@ -5,6 +5,7 @@ export interface ConversationDisplayIdentity {
   avatarName: string;
   profileImageUrl: string | null;
   whatsappName: string | null;
+  declaredContactName: string | null;
   patientName: string | null;
   listContext: string | null;
   headerContext: string;
@@ -15,27 +16,32 @@ export function getConversationDisplayIdentity(
   conversation: Conversation,
 ): ConversationDisplayIdentity {
   const whatsappName = normalizeText(conversation.profileName);
+  const declaredContactName = normalizeText(conversation.contactDisplayName);
   const patientName = normalizeText(
     [conversation.patient.firstName, conversation.patient.lastName]
       .filter(Boolean)
       .join(" "),
   );
   const phone = formatPhoneDisplay(conversation.patient.phone);
-  const displayName = patientName ?? whatsappName ?? phone;
-  const sameVisibleName =
-    !!whatsappName &&
-    !!patientName &&
-    whatsappName.toLocaleLowerCase("es-AR") ===
-      patientName.toLocaleLowerCase("es-AR");
+  const displayName = patientName ?? declaredContactName ?? whatsappName ?? phone;
 
   const contextParts = [
-    patientName && whatsappName && !sameVisibleName
+    shouldShowSecondaryName(patientName, declaredContactName)
+      ? `Declarado: ${declaredContactName}`
+      : null,
+    patientName && whatsappName && !sameVisibleName(patientName, whatsappName)
       ? `WhatsApp: ${whatsappName}`
       : null,
-    patientName && conversation.patient.dni
+    !patientName &&
+    declaredContactName &&
+    whatsappName &&
+    !sameVisibleName(declaredContactName, whatsappName)
+      ? `WhatsApp: ${whatsappName}`
+      : null,
+    (patientName || declaredContactName) && conversation.patient.dni
       ? `DNI ${conversation.patient.dni}`
       : null,
-    patientName || whatsappName ? phone : null,
+    displayName !== phone ? phone : null,
   ].filter(Boolean) as string[];
   const visibleContext = contextParts.join(" · ");
   const fallbackContext =
@@ -46,11 +52,34 @@ export function getConversationDisplayIdentity(
     avatarName: displayName,
     profileImageUrl: normalizeText(conversation.profileImageUrl),
     whatsappName,
+    declaredContactName,
     patientName,
     listContext: visibleContext || null,
     headerContext: visibleContext || fallbackContext,
     panelContext: visibleContext || null,
   };
+}
+
+function sameVisibleName(
+  first: string | null | undefined,
+  second: string | null | undefined,
+): boolean {
+  return (
+    !!first &&
+    !!second &&
+    first.toLocaleLowerCase("es-AR") === second.toLocaleLowerCase("es-AR")
+  );
+}
+
+function shouldShowSecondaryName(
+  patientName: string | null,
+  declaredContactName: string | null,
+): boolean {
+  return (
+    !!patientName &&
+    !!declaredContactName &&
+    !sameVisibleName(patientName, declaredContactName)
+  );
 }
 
 function normalizeText(value: string | null | undefined): string | null {

--- a/src/components/Conversations/index.tsx
+++ b/src/components/Conversations/index.tsx
@@ -1316,6 +1316,10 @@ export function PatientPanel({
             {identity.whatsappName && (
               <InfoRow label="WhatsApp" value={identity.whatsappName} />
             )}
+            {identity.declaredContactName &&
+              identity.declaredContactName !== identity.displayName && (
+                <InfoRow label="Declarado" value={identity.declaredContactName} />
+              )}
             {identity.patientName &&
               identity.patientName !== identity.displayName && (
                 <InfoRow label="Paciente" value={identity.patientName} />

--- a/src/types/Conversations/index.ts
+++ b/src/types/Conversations/index.ts
@@ -62,6 +62,7 @@ export interface ConversationInternalNote {
 export interface Conversation {
   id: string;
   profileName?: string | null;
+  contactDisplayName?: string | null;
   profileImageUrl?: string | null;
   patient: ConversationPatientCard;
   status: ConversationStatus;


### PR DESCRIPTION
## Summary\n- add contactDisplayName to conversation types\n- use display priority: linked patient, declared contact name, WhatsApp profile, phone\n- show declared identity context in the patient panel\n\n## Tests\n- npm test -- --run src/components/Conversations/ConversationIdentity.test.tsx\n- npm run type-check\n- npm run lint\n- npm run build