### PR TITLE
feat: rediseñar reporte de turnos (embudo + filtros claros)

### DIFF
--- a/src/components/Appointments-Analytics/AppointmentsManagementDashboardContainer.tsx
+++ b/src/components/Appointments-Analytics/AppointmentsManagementDashboardContainer.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { format, subMonths } from "date-fns";
-import { BarChart3, FilterX } from "lucide-react";
+import { BarChart3, X } from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { DoctorSelect } from "@/components/Appointments/Select/DoctorSelect";
 import { ConsultationTypeSelect } from "@/components/Appointments/Select/ConsultationTypeSelect";
@@ -11,6 +11,7 @@ import { ConsultationTypeVolumeChart } from "./ConsultationTypeVolumeChart";
 import { OriginMixChart } from "./OriginMixChart";
 import { DoctorOriginChart } from "./DoctorOriginChart";
 import { CancellationTrendChart } from "./CancellationTrendChart";
+import { formatNumber } from "./chartTheme";
 import {
   useAppointmentsAnalyticsByConsultationType,
   useAppointmentsAnalyticsByDoctor,
@@ -19,13 +20,60 @@ import {
   useAppointmentsAnalyticsOverview,
   useOverturnAnalyticsOverview,
 } from "@/hooks/Appointments-Analytics";
-import { AppointmentOrigin } from "@/types/Appointment/Appointment";
+import { useDoctors } from "@/hooks/Doctor/useDoctors";
+import { useConsultationTypes } from "@/hooks/ConsultationType";
+import { formatDoctorName } from "@/common/helpers/helpers";
+import {
+  AppointmentOrigin,
+  AppointmentOriginLabels,
+} from "@/types/Appointment/Appointment";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 
 interface AppointmentsManagementDashboardContainerProps {
   showHeader?: boolean;
+}
+
+function FilterField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function ActiveFilterChip({
+  label,
+  value,
+  onRemove,
+}: {
+  label: string;
+  value: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border bg-background py-1 pl-3 pr-1.5 text-sm">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="font-medium text-foreground">{value}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Quitar filtro ${label}`}
+        className="ml-0.5 flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  );
 }
 
 export function AppointmentsManagementDashboardContainer({
@@ -36,7 +84,9 @@ export function AppointmentsManagementDashboardContainer({
   );
   const [dateTo, setDateTo] = useState(() => format(new Date(), "yyyy-MM-dd"));
   const [doctorId, setDoctorId] = useState<number | undefined>(undefined);
-  const [consultationTypeId, setConsultationTypeId] = useState<number | undefined>(undefined);
+  const [consultationTypeId, setConsultationTypeId] = useState<
+    number | undefined
+  >(undefined);
   const [origin, setOrigin] = useState<AppointmentOrigin | undefined>(undefined);
 
   const filters = {
@@ -54,7 +104,20 @@ export function AppointmentsManagementDashboardContainer({
   const cancellationsQuery = useAppointmentsAnalyticsCancellations(filters);
   const overturnOverviewQuery = useOverturnAnalyticsOverview(filters);
 
-  const isSummaryLoading = overviewQuery.isLoading || overturnOverviewQuery.isLoading;
+  const { doctors } = useDoctors({ auth: true, fetchDoctors: true });
+  const { consultationTypes } = useConsultationTypes(
+    doctorId ? { doctorId } : undefined
+  );
+
+  const selectedDoctor = doctorId
+    ? doctors.find((d) => Number(d.userId) === doctorId)
+    : undefined;
+  const selectedType = consultationTypeId
+    ? consultationTypes.find((t) => t.id === consultationTypeId)
+    : undefined;
+
+  const isSummaryLoading =
+    overviewQuery.isLoading || overturnOverviewQuery.isLoading;
   const hasActiveFilters = !!doctorId || !!consultationTypeId || !!origin;
 
   const clearNonDateFilters = () => {
@@ -63,8 +126,14 @@ export function AppointmentsManagementDashboardContainer({
     setOrigin(undefined);
   };
 
+  const overturnByDoctor = overturnOverviewQuery.data?.byDoctor ?? [];
+  const maxOverturn = overturnByDoctor.reduce(
+    (max, item) => Math.max(max, item.total),
+    0
+  );
+
   return (
-    <div className={`space-y-8 ${showHeader ? "p-6" : ""}`}>
+    <div className={`space-y-7 ${showHeader ? "p-6" : ""}`}>
       {showHeader && (
         <PageHeader
           breadcrumbItems={[
@@ -77,14 +146,8 @@ export function AppointmentsManagementDashboardContainer({
         />
       )}
 
-      <div className="flex flex-col gap-5 rounded-2xl border bg-card p-5 md:p-6">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold">Filtros</h2>
-            <p className="text-sm text-muted-foreground">
-              Acotá el análisis por período, médico, tipo de turno y origen.
-            </p>
-          </div>
+      <div className="flex flex-col gap-4 rounded-2xl border bg-card p-5">
+        <FilterField label="Período">
           <DateRangeFilter
             from={dateFrom}
             to={dateTo}
@@ -93,46 +156,68 @@ export function AppointmentsManagementDashboardContainer({
               setDateTo(nextTo);
             }}
           />
-        </div>
+        </FilterField>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <DoctorSelect
-            value={doctorId}
-            onValueChange={setDoctorId}
-            placeholder="Todos los médicos"
-            allowClear
-          />
-          <ConsultationTypeSelect
-            value={consultationTypeId}
-            onValueChange={setConsultationTypeId}
-            placeholder="Todos los tipos"
-          />
-          <OriginSelect value={origin} onValueChange={setOrigin} />
+          <FilterField label="Médico">
+            <DoctorSelect
+              value={doctorId}
+              onValueChange={setDoctorId}
+              placeholder="Todos los médicos"
+              allowClear
+            />
+          </FilterField>
+          <FilterField label="Tipo de turno">
+            <ConsultationTypeSelect
+              value={consultationTypeId}
+              onValueChange={setConsultationTypeId}
+              placeholder="Todos los tipos"
+            />
+          </FilterField>
+          <FilterField label="Origen">
+            <OriginSelect value={origin} onValueChange={setOrigin} />
+          </FilterField>
         </div>
 
-        <div className="flex flex-col gap-3 border-t pt-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {doctorId && <Badge variant="secondary">Médico filtrado</Badge>}
-            {consultationTypeId && <Badge variant="secondary">Tipo filtrado</Badge>}
-            {origin && <Badge variant="secondary">Origen filtrado</Badge>}
-            {!hasActiveFilters && (
-              <span className="text-sm text-muted-foreground">
-                Sin filtros adicionales activos.
-              </span>
+        {hasActiveFilters && (
+          <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+            <span className="text-xs font-medium text-muted-foreground">
+              Filtros activos:
+            </span>
+            {doctorId && (
+              <ActiveFilterChip
+                label="Médico"
+                value={
+                  selectedDoctor ? formatDoctorName(selectedDoctor) : "Seleccionado"
+                }
+                onRemove={() => setDoctorId(undefined)}
+              />
             )}
+            {consultationTypeId && (
+              <ActiveFilterChip
+                label="Tipo"
+                value={selectedType ? selectedType.name : "Seleccionado"}
+                onRemove={() => setConsultationTypeId(undefined)}
+              />
+            )}
+            {origin && (
+              <ActiveFilterChip
+                label="Origen"
+                value={AppointmentOriginLabels[origin]}
+                onRemove={() => setOrigin(undefined)}
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={clearNonDateFilters}
+              className="ml-auto h-8 text-muted-foreground hover:text-foreground"
+            >
+              Limpiar todo
+            </Button>
           </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={clearNonDateFilters}
-            disabled={!hasActiveFilters}
-            className="w-full md:w-auto"
-          >
-            <FilterX className="mr-2 h-4 w-4" />
-            Limpiar filtros
-          </Button>
-        </div>
+        )}
       </div>
 
       <ManagementSummaryCards
@@ -141,7 +226,7 @@ export function AppointmentsManagementDashboardContainer({
         isLoading={isSummaryLoading}
       />
 
-      <div className="grid gap-7 xl:grid-cols-2">
+      <div className="grid gap-6 xl:grid-cols-2">
         <ConsultationTypeVolumeChart
           data={byTypeQuery.data}
           isLoading={byTypeQuery.isLoading}
@@ -152,7 +237,7 @@ export function AppointmentsManagementDashboardContainer({
         />
       </div>
 
-      <div className="grid gap-7 xl:grid-cols-2">
+      <div className="grid gap-6 xl:grid-cols-2">
         <CancellationTrendChart
           data={cancellationsQuery.data?.trend}
           isLoading={cancellationsQuery.isLoading}
@@ -163,21 +248,35 @@ export function AppointmentsManagementDashboardContainer({
         />
       </div>
 
-      <Card className="overflow-hidden">
-        <CardHeader>
-          <CardTitle>Sobreturnos por médico</CardTitle>
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Sobreturnos por médico</CardTitle>
         </CardHeader>
-        <CardContent className="pt-0">
-          {!overturnOverviewQuery.data?.byDoctor?.length ? (
-            <div className="text-sm text-muted-foreground">
+        <CardContent>
+          {!overturnByDoctor.length ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
               Sin sobreturnos para el período seleccionado.
             </div>
           ) : (
             <div className="space-y-3">
-              {overturnOverviewQuery.data.byDoctor.slice(0, 8).map((item) => (
-                <div key={item.id ?? item.label} className="flex items-center justify-between rounded-lg border px-4 py-3">
-                  <span className="text-sm font-medium">{item.label}</span>
-                  <span className="text-sm text-muted-foreground">{item.total}</span>
+              {overturnByDoctor.slice(0, 8).map((item) => (
+                <div key={item.id ?? item.label} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">{item.label}</span>
+                    <span className="tabular-nums text-muted-foreground">
+                      {formatNumber(item.total)}
+                    </span>
+                  </div>
+                  <div className="h-2 overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-purple-500"
+                      style={{
+                        width: `${
+                          maxOverturn ? (item.total / maxOverturn) * 100 : 0
+                        }%`,
+                      }}
+                    />
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/components/Appointments-Analytics/CancellationTrendChart.tsx
+++ b/src/components/Appointments-Analytics/CancellationTrendChart.tsx
@@ -1,7 +1,14 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   CartesianGrid,
+  Legend,
   Line,
   LineChart,
   ResponsiveContainer,
@@ -12,6 +19,8 @@ import {
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { AppointmentsAnalyticsTrendPoint } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import { CHART_AXIS_COLOR, CHART_COLORS, CHART_GRID_COLOR } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 interface Props {
   data?: AppointmentsAnalyticsTrendPoint[];
@@ -21,13 +30,16 @@ interface Props {
 export function CancellationTrendChart({ data, isLoading }: Props) {
   const chartData = (data ?? []).map((item) => ({
     ...item,
-    bucketLabel: format(new Date(`${item.bucket}T00:00:00`), "MMM yyyy", { locale: es }),
+    bucketLabel: format(new Date(`${item.bucket}T00:00:00`), "MMM yyyy", {
+      locale: es,
+    }),
   }));
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Evolución de cancelaciones</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Evolución de cancelaciones</CardTitle>
+        <CardDescription>Quién cancela los turnos a lo largo del tiempo.</CardDescription>
       </CardHeader>
       <CardContent className="h-[320px]">
         {isLoading ? (
@@ -39,12 +51,37 @@ export function CancellationTrendChart({ data, isLoading }: Props) {
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 10, right: 16, left: -16, bottom: 12 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="bucketLabel" />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Line type="monotone" dataKey="cancelledByPatient" stroke="#EA580C" strokeWidth={2} name="Paciente" />
-              <Line type="monotone" dataKey="cancelledBySecretary" stroke="#DC2626" strokeWidth={2} name="Secretaría" />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART_GRID_COLOR} />
+              <XAxis
+                dataKey="bucketLabel"
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={{ stroke: CHART_GRID_COLOR }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip content={<ChartTooltip />} />
+              <Legend iconType="plainline" wrapperStyle={{ fontSize: 12 }} />
+              <Line
+                type="monotone"
+                dataKey="cancelledByPatient"
+                stroke={CHART_COLORS.orange}
+                strokeWidth={2}
+                dot={false}
+                name="Paciente"
+              />
+              <Line
+                type="monotone"
+                dataKey="cancelledBySecretary"
+                stroke={CHART_COLORS.red}
+                strokeWidth={2}
+                dot={false}
+                name="Secretaría"
+              />
             </LineChart>
           </ResponsiveContainer>
         )}

--- a/src/components/Appointments-Analytics/ChartTooltip.tsx
+++ b/src/components/Appointments-Analytics/ChartTooltip.tsx
@@ -1,0 +1,49 @@
+import { formatNumber } from "./chartTheme";
+
+interface ChartTooltipEntry {
+  name?: string;
+  value?: number | string;
+  color?: string;
+  dataKey?: string | number;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  payload?: ChartTooltipEntry[];
+  label?: string | number;
+}
+
+export function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 shadow-md">
+      {label !== undefined && label !== "" && (
+        <p className="mb-1 text-xs font-medium text-foreground">{label}</p>
+      )}
+      <div className="space-y-0.5">
+        {payload.map((entry, index) => (
+          <div
+            key={`${entry.dataKey ?? entry.name ?? index}`}
+            className="flex items-center justify-between gap-4 text-xs"
+          >
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              {entry.color && (
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+              )}
+              {entry.name}
+            </span>
+            <span className="font-semibold text-foreground">
+              {typeof entry.value === "number"
+                ? formatNumber(entry.value)
+                : entry.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Appointments-Analytics/ConsultationTypeVolumeChart.tsx
+++ b/src/components/Appointments-Analytics/ConsultationTypeVolumeChart.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Bar,
@@ -10,6 +16,8 @@ import {
   YAxis,
 } from "recharts";
 import { AppointmentsAnalyticsGroupedItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import { CHART_AXIS_COLOR, CHART_COLORS, CHART_GRID_COLOR } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 interface Props {
   data?: AppointmentsAnalyticsGroupedItem[];
@@ -24,8 +32,9 @@ export function ConsultationTypeVolumeChart({ data, isLoading }: Props) {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Mix por tipo de turno</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Mix por tipo de turno</CardTitle>
+        <CardDescription>Volumen de turnos por cada tipo de consulta.</CardDescription>
       </CardHeader>
       <CardContent className="h-[320px]">
         {isLoading ? (
@@ -37,11 +46,25 @@ export function ConsultationTypeVolumeChart({ data, isLoading }: Props) {
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 10, right: 16, left: -16, bottom: 32 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="name" angle={-20} textAnchor="end" interval={0} height={72} />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Bar dataKey="total" fill="#2563EB" radius={[6, 6, 0, 0]} />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART_GRID_COLOR} />
+              <XAxis
+                dataKey="name"
+                angle={-20}
+                textAnchor="end"
+                interval={0}
+                height={72}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={{ stroke: CHART_GRID_COLOR }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip cursor={{ fill: "rgba(37, 99, 235, 0.06)" }} content={<ChartTooltip />} />
+              <Bar dataKey="total" name="Turnos" fill={CHART_COLORS.blue} radius={[6, 6, 0, 0]} maxBarSize={48} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/src/components/Appointments-Analytics/DateRangeFilter.tsx
+++ b/src/components/Appointments-Analytics/DateRangeFilter.tsx
@@ -123,18 +123,30 @@ export function DateRangeFilter({
     return `${format(fromDate, "d MMM yyyy", { locale: es })} – ${format(toDate, "d MMM yyyy", { locale: es })}`;
   };
 
+  const isPresetActive = (preset: Preset) => {
+    const { from: presetFrom, to: presetTo } = preset.getValue();
+    return (
+      format(presetFrom, "yyyy-MM-dd") === from &&
+      format(presetTo, "yyyy-MM-dd") === to
+    );
+  };
+
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {presets.map((preset) => (
-        <Button
-          key={preset.label}
-          variant="outline"
-          size="sm"
-          onClick={() => handlePreset(preset)}
-        >
-          {preset.label}
-        </Button>
-      ))}
+      {presets.map((preset) => {
+        const active = isPresetActive(preset);
+        return (
+          <Button
+            key={preset.label}
+            variant={active ? "default" : "outline"}
+            size="sm"
+            aria-pressed={active}
+            onClick={() => handlePreset(preset)}
+          >
+            {preset.label}
+          </Button>
+        );
+      })}
 
       <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
         <PopoverTrigger asChild>

--- a/src/components/Appointments-Analytics/DoctorOriginChart.tsx
+++ b/src/components/Appointments-Analytics/DoctorOriginChart.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Bar,
@@ -11,7 +17,12 @@ import {
   YAxis,
 } from "recharts";
 import { AppointmentsAnalyticsDoctorItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
-import { AppointmentOrigin, AppointmentOriginLabels } from "@/types/Appointment/Appointment";
+import {
+  AppointmentOrigin,
+  AppointmentOriginLabels,
+} from "@/types/Appointment/Appointment";
+import { CHART_AXIS_COLOR, CHART_COLORS, CHART_GRID_COLOR } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 const ORIGINS = [
   AppointmentOrigin.SECRETARY,
@@ -21,10 +32,10 @@ const ORIGINS = [
 ];
 
 const ORIGIN_COLORS: Record<AppointmentOrigin, string> = {
-  [AppointmentOrigin.SECRETARY]: "#2563EB",
-  [AppointmentOrigin.WEB_PATIENT]: "#16A34A",
-  [AppointmentOrigin.WEB_GUEST]: "#EA580C",
-  [AppointmentOrigin.DOCTOR]: "#7C3AED",
+  [AppointmentOrigin.SECRETARY]: CHART_COLORS.blue,
+  [AppointmentOrigin.WEB_PATIENT]: CHART_COLORS.green,
+  [AppointmentOrigin.WEB_GUEST]: CHART_COLORS.orange,
+  [AppointmentOrigin.DOCTOR]: CHART_COLORS.purple,
 };
 
 interface Props {
@@ -49,8 +60,9 @@ export function DoctorOriginChart({ data, isLoading }: Props) {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Origen por médico</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Origen por médico</CardTitle>
+        <CardDescription>Cómo se reparten los turnos de cada médico según su origen.</CardDescription>
       </CardHeader>
       <CardContent className="h-[360px]">
         {isLoading ? (
@@ -62,11 +74,25 @@ export function DoctorOriginChart({ data, isLoading }: Props) {
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 10, right: 16, left: -16, bottom: 48 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="name" angle={-20} textAnchor="end" interval={0} height={86} />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Legend />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART_GRID_COLOR} />
+              <XAxis
+                dataKey="name"
+                angle={-20}
+                textAnchor="end"
+                interval={0}
+                height={86}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={{ stroke: CHART_GRID_COLOR }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip cursor={{ fill: "rgba(100, 116, 139, 0.06)" }} content={<ChartTooltip />} />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
               {ORIGINS.map((origin) => (
                 <Bar
                   key={origin}
@@ -74,6 +100,7 @@ export function DoctorOriginChart({ data, isLoading }: Props) {
                   stackId="origin"
                   fill={ORIGIN_COLORS[origin]}
                   name={AppointmentOriginLabels[origin]}
+                  maxBarSize={48}
                 />
               ))}
             </BarChart>

--- a/src/components/Appointments-Analytics/ManagementSummaryCards.tsx
+++ b/src/components/Appointments-Analytics/ManagementSummaryCards.tsx
@@ -1,10 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CalendarDays, CheckCircle2, Clock3, RotateCcw, XCircle } from "lucide-react";
+import { ChevronRight, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 import {
   AppointmentsAnalyticsOverview,
   OverturnAnalyticsOverview,
 } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import { formatNumber } from "./chartTheme";
 
 interface Props {
   overview?: AppointmentsAnalyticsOverview;
@@ -12,39 +14,129 @@ interface Props {
   isLoading: boolean;
 }
 
-function StatCard({
-  title,
+type StepTone = "neutral" | "blue" | "green" | "red";
+
+const TONE_STYLES: Record<StepTone, { value: string; share: string }> = {
+  neutral: { value: "text-slate-900", share: "text-slate-500" },
+  blue: { value: "text-blue-700", share: "text-blue-600" },
+  green: { value: "text-green-700", share: "text-green-600" },
+  red: { value: "text-red-700", share: "text-red-600" },
+};
+
+function FunnelStep({
+  label,
   value,
-  icon,
+  share,
+  tone,
   isLoading,
 }: {
-  title: string;
-  value: string | number;
-  icon: React.ReactNode;
+  label: string;
+  value: number;
+  share?: string;
+  tone: StepTone;
   isLoading: boolean;
 }) {
+  const styles = TONE_STYLES[tone];
+
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
-        {icon}
-      </CardHeader>
-      <CardContent>
-        {isLoading ? <Skeleton className="h-8 w-20" /> : <div className="text-2xl font-bold">{value}</div>}
-      </CardContent>
-    </Card>
+    <div className="min-w-[120px] flex-1 px-2 py-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {isLoading ? (
+        <Skeleton className="mt-1 h-8 w-16" />
+      ) : (
+        <div className="mt-0.5 flex items-baseline gap-2">
+          <span className={cn("text-3xl font-bold leading-none", styles.value)}>
+            {formatNumber(value)}
+          </span>
+          {share && (
+            <span className={cn("text-sm font-medium", styles.share)}>{share}</span>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
-export function ManagementSummaryCards({ overview, overturnOverview, isLoading }: Props) {
+function StepArrow() {
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
-      <StatCard title="Turnos creados" value={overview?.totalCreated ?? 0} icon={<Clock3 className="h-5 w-5 text-slate-500" />} isLoading={isLoading} />
-      <StatCard title="Turnos agendados" value={overview?.totalScheduled ?? 0} icon={<CalendarDays className="h-5 w-5 text-blue-600" />} isLoading={isLoading} />
-      <StatCard title="Completados" value={overview?.totalCompleted ?? 0} icon={<CheckCircle2 className="h-5 w-5 text-green-600" />} isLoading={isLoading} />
-      <StatCard title="Cancelados" value={overview?.totalCancelled ?? 0} icon={<XCircle className="h-5 w-5 text-red-600" />} isLoading={isLoading} />
-      <StatCard title="Tasa cancelación" value={`${overview?.cancellationRate ?? 0}%`} icon={<RotateCcw className="h-5 w-5 text-amber-600" />} isLoading={isLoading} />
-      <StatCard title="Sobreturnos" value={overturnOverview?.totalCreated ?? 0} icon={<CalendarDays className="h-5 w-5 text-purple-600" />} isLoading={isLoading} />
-    </div>
+    <ChevronRight className="hidden h-5 w-5 shrink-0 self-center text-muted-foreground/40 md:block" />
+  );
+}
+
+export function ManagementSummaryCards({
+  overview,
+  overturnOverview,
+  isLoading,
+}: Props) {
+  const created = overview?.totalCreated ?? 0;
+  const scheduled = overview?.totalScheduled ?? 0;
+  const completed = overview?.totalCompleted ?? 0;
+  const cancelled = overview?.totalCancelled ?? 0;
+  const cancellationRate = overview?.cancellationRate ?? 0;
+  const overturns = overturnOverview?.totalCreated ?? 0;
+
+  const share = (value: number): string | undefined => {
+    if (!created) return undefined;
+    return `${Math.round((value / created) * 100)}%`;
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Recorrido de los turnos</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+          <div className="flex flex-1 flex-col gap-2 rounded-xl border bg-muted/30 p-3 md:flex-row md:items-center md:gap-1">
+            <FunnelStep
+              label="Creados"
+              value={created}
+              tone="neutral"
+              isLoading={isLoading}
+            />
+            <StepArrow />
+            <FunnelStep
+              label="Agendados"
+              value={scheduled}
+              share={share(scheduled)}
+              tone="blue"
+              isLoading={isLoading}
+            />
+            <StepArrow />
+            <FunnelStep
+              label="Completados"
+              value={completed}
+              share={share(completed)}
+              tone="green"
+              isLoading={isLoading}
+            />
+            <div className="hidden w-px self-stretch bg-border md:block" />
+            <FunnelStep
+              label="Cancelados"
+              value={cancelled}
+              share={`${formatNumber(cancellationRate)}%`}
+              tone="red"
+              isLoading={isLoading}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-xl border border-purple-100 bg-purple-50/60 px-4 py-3 lg:w-48 lg:flex-col lg:items-start lg:justify-center">
+            <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-purple-700">
+              <Plus className="h-3.5 w-3.5" />
+              Sobreturnos
+            </div>
+            {isLoading ? (
+              <Skeleton className="h-8 w-12" />
+            ) : (
+              <span className="text-3xl font-bold leading-none text-purple-700">
+                {formatNumber(overturns)}
+              </span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/Appointments-Analytics/OriginMixChart.tsx
+++ b/src/components/Appointments-Analytics/OriginMixChart.tsx
@@ -1,15 +1,15 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
-  Cell,
-  Pie,
-  PieChart,
-  ResponsiveContainer,
-  Tooltip,
-} from "recharts";
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { AppointmentsAnalyticsOriginItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
-
-const COLORS = ["#2563EB", "#16A34A", "#EA580C", "#7C3AED", "#DC2626"];
+import { CHART_PALETTE, formatNumber } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 interface Props {
   data?: AppointmentsAnalyticsOriginItem[];
@@ -17,15 +17,19 @@ interface Props {
 }
 
 export function OriginMixChart({ data, isLoading }: Props) {
-  const chartData = (data ?? []).map((item) => ({
+  const chartData = (data ?? []).map((item, index) => ({
     name: item.label,
     value: item.total,
+    color: CHART_PALETTE[index % CHART_PALETTE.length],
   }));
+
+  const total = chartData.reduce((sum, item) => sum + item.value, 0);
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Origen de turnos</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Origen de turnos</CardTitle>
+        <CardDescription>Por dónde se generan los turnos del período.</CardDescription>
       </CardHeader>
       <CardContent className="h-[320px]">
         {isLoading ? (
@@ -35,16 +39,54 @@ export function OriginMixChart({ data, isLoading }: Props) {
             Sin datos para el período seleccionado.
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie data={chartData} dataKey="value" nameKey="name" innerRadius={64} outerRadius={100} paddingAngle={2}>
-                {chartData.map((entry, index) => (
-                  <Cell key={entry.name} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="flex h-full flex-col items-center gap-4 sm:flex-row">
+            <div className="h-[200px] w-full sm:h-full sm:flex-1">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    dataKey="value"
+                    nameKey="name"
+                    innerRadius={60}
+                    outerRadius={96}
+                    paddingAngle={2}
+                  >
+                    {chartData.map((entry) => (
+                      <Cell key={entry.name} fill={entry.color} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<ChartTooltip />} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+
+            <ul className="w-full space-y-2 sm:w-44">
+              {chartData.map((entry) => {
+                const percent = total
+                  ? Math.round((entry.value / total) * 100)
+                  : 0;
+                return (
+                  <li
+                    key={entry.name}
+                    className="flex items-center justify-between gap-2 text-sm"
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: entry.color }}
+                      />
+                      <span className="truncate text-muted-foreground">
+                        {entry.name}
+                      </span>
+                    </span>
+                    <span className="shrink-0 font-medium tabular-nums">
+                      {formatNumber(entry.value)} · {percent}%
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/Appointments-Analytics/chartTheme.ts
+++ b/src/components/Appointments-Analytics/chartTheme.ts
@@ -1,0 +1,22 @@
+export const CHART_COLORS = {
+  blue: "#2563EB",
+  green: "#16A34A",
+  orange: "#EA580C",
+  purple: "#7C3AED",
+  red: "#DC2626",
+  amber: "#D97706",
+} as const;
+
+export const CHART_PALETTE = [
+  CHART_COLORS.blue,
+  CHART_COLORS.green,
+  CHART_COLORS.orange,
+  CHART_COLORS.purple,
+  CHART_COLORS.red,
+];
+
+export const CHART_GRID_COLOR = "#E2E8F0";
+export const CHART_AXIS_COLOR = "#64748B";
+
+export const formatNumber = (value: number): string =>
+  value.toLocaleString("es-AR");

--- a/src/pages/protected/Admin/Appointments-Reports/index.tsx
+++ b/src/pages/protected/Admin/Appointments-Reports/index.tsx
@@ -4,7 +4,6 @@ import { PageHeader } from "@/components/PageHeader";
 import { AppointmentsManagementDashboardContainer } from "@/components/Appointments-Analytics";
 import { TotemReportDashboardContainer } from "@/components/Totem-Analytics";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent } from "@/components/ui/card";
 
 const AppointmentsReportsPage = () => {
   return (
@@ -24,26 +23,22 @@ const AppointmentsReportsPage = () => {
         />
 
         <Tabs defaultValue="appointments" className="space-y-6">
-          <Card className="border-border/70">
-            <CardContent className="pt-6">
-              <TabsList className="h-auto w-full flex-wrap justify-start gap-2 bg-transparent p-0">
-                <TabsTrigger
-                  value="appointments"
-                  className="border border-border/70 px-4 py-2 data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                >
-                  <BarChart3 className="mr-2 h-4 w-4" />
-                  Turnos
-                </TabsTrigger>
-                <TabsTrigger
-                  value="totem"
-                  className="border border-border/70 px-4 py-2 data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                >
-                  <Ticket className="mr-2 h-4 w-4" />
-                  Totem
-                </TabsTrigger>
-              </TabsList>
-            </CardContent>
-          </Card>
+          <TabsList className="h-auto w-full flex-wrap justify-start gap-2 border-b bg-transparent p-0">
+            <TabsTrigger
+              value="appointments"
+              className="rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
+            >
+              <BarChart3 className="mr-2 h-4 w-4" />
+              Turnos
+            </TabsTrigger>
+            <TabsTrigger
+              value="totem"
+              className="rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
+            >
+              <Ticket className="mr-2 h-4 w-4" />
+              Totem
+            </TabsTrigger>
+          </TabsList>
 
           <TabsContent value="appointments" className="mt-0">
             <AppointmentsManagementDashboardContainer showHeader={false} />


### PR DESCRIPTION
## Resumen

Rediseño completo de la pantalla **Reportes de Turnos** (`/admin/reportes-turnos`, tab Turnos). El pedido fue que las cards estaban feas y los filtros no se entendían. Sigue la guía UX del proyecto: es un reporte gerencial (caso válido de métricas), pero ahora cada número tiene una pregunta detrás en vez de ser 6 cifras sueltas.

### Cambios

- **Cards → Embudo del turno.** Reemplazo las 6 cards idénticas por el recorrido real `Creados → Agendados → Completados`, con cancelados (y su tasa) como rama y sobreturnos como dato de apoyo. Cada paso muestra su % sobre los creados.
- **Filtros claros.** Cada control con label visible. Chips de filtro activo que muestran el **valor real** (ej: "Médico: Dr. Pérez ✕") y se quitan uno a uno. Botón "Limpiar todo" solo cuando hay filtros.
- **Período.** El preset activo (Esta semana / Último mes / etc.) queda marcado en `DateRangeFilter`.
- **Gráficos consistentes.** Paleta y tooltip en español unificados en `chartTheme.ts` + `ChartTooltip.tsx` (elimina duplicación entre los 4 gráficos). Donut de origen con leyenda y porcentajes.
- **Sobreturnos por médico.** De lista cruda a filas con barra de proporción.
- **Tabs** de la página más livianos (sin la Card que los envolvía).

No se tocó lógica de datos, hooks, endpoints ni tipos: es 100% rediseño de UI. El tab de Totem queda igual.

## Test plan

- [ ] Entrar a `/admin/reportes-turnos` (rol Administrador) → tab Turnos
- [ ] Verificar el embudo: Creados → Agendados → Completados, cancelados con tasa, sobreturnos
- [ ] Aplicar filtros de médico, tipo y origen → aparecen chips con el nombre real y se quitan individualmente
- [ ] Cambiar el período con presets → el preset activo queda marcado
- [ ] Revisar los 4 gráficos: tooltips en español, donut con leyenda/porcentajes
- [ ] Verificar el bloque de sobreturnos con barra de proporción
- [ ] `npm run type-check`, `npm run lint` y `npm run build` pasan

🤖 Generated with [Claude Code](https://claude.com/claude-code)