### PR TITLE
fix: mostrar origen de turnos en español en el donut

### DIFF
--- a/src/components/Appointments-Analytics/OriginMixChart.tsx
+++ b/src/components/Appointments-Analytics/OriginMixChart.tsx
@@ -8,6 +8,10 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { AppointmentsAnalyticsOriginItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import {
+  AppointmentOrigin,
+  AppointmentOriginLabels,
+} from "@/types/Appointment/Appointment";
 import { CHART_PALETTE, formatNumber } from "./chartTheme";
 import { ChartTooltip } from "./ChartTooltip";
 
@@ -16,9 +20,20 @@ interface Props {
   isLoading: boolean;
 }
 
+function resolveOriginName(item: AppointmentsAnalyticsOriginItem): string {
+  if (item.origin && AppointmentOriginLabels[item.origin]) {
+    return AppointmentOriginLabels[item.origin];
+  }
+  const fromLabel = AppointmentOriginLabels[item.label as AppointmentOrigin];
+  if (fromLabel) {
+    return fromLabel;
+  }
+  return item.label || "Sin origen";
+}
+
 export function OriginMixChart({ data, isLoading }: Props) {
   const chartData = (data ?? []).map((item, index) => ({
-    name: item.label,
+    name: resolveOriginName(item),
     value: item.total,
     color: CHART_PALETTE[index % CHART_PALETTE.length],
   }));


### PR DESCRIPTION
## Resumen

Seguimiento del #110. El donut **"Origen de turnos"** mostraba los valores crudos del backend (`SECRETARY`, `WEB_PATIENT`, `WEB_GUEST`, `DOCTOR`). Ahora los traduce con `AppointmentOriginLabels`:

- `SECRETARY` → Secretaría
- `WEB_PATIENT` → Paciente (web)
- `WEB_GUEST` → Invitado (web pública)
- `DOCTOR` → Médico (autogestión)

La traducción es robusta: funciona tanto si el backend manda el campo `origin` como si el valor crudo viene en `label`. La leyenda del donut queda en español.

## Test plan

- [ ] `/admin/reportes-turnos` → tab Turnos → donut "Origen de turnos" con nombres y leyenda en español

🤖 Generated with [Claude Code](https://claude.com/claude-code)