### PR TITLE
feat: rediseñar reporte Totem y corregir cruces por fecha

### DIFF
--- a/src/components/Totem-Analytics/TotemActivitySummary.tsx
+++ b/src/components/Totem-Analytics/TotemActivitySummary.tsx
@@ -1,0 +1,84 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { formatNumber } from "@/components/Appointments-Analytics/chartTheme";
+
+interface TotemActivitySummaryProps {
+  totalTickets: number;
+  scheduled: number;
+  invited: number;
+  administrative: number;
+  unregistered: number;
+  isLoading: boolean;
+}
+
+function Stat({
+  label,
+  value,
+  isLoading,
+  emphasis = false,
+}: {
+  label: string;
+  value: number;
+  isLoading: boolean;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="min-w-[110px] flex-1 px-3 py-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {isLoading ? (
+        <Skeleton className="mt-1 h-8 w-16" />
+      ) : (
+        <p
+          className={cn(
+            "mt-0.5 font-bold leading-none",
+            emphasis ? "text-3xl text-slate-900" : "text-2xl text-slate-700"
+          )}
+        >
+          {formatNumber(value)}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function TotemActivitySummary({
+  totalTickets,
+  scheduled,
+  invited,
+  administrative,
+  unregistered,
+  isLoading,
+}: TotemActivitySummaryProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Actividad del tótem</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col divide-y rounded-xl border bg-muted/30 md:flex-row md:divide-x md:divide-y-0">
+          <Stat
+            label="Tickets"
+            value={totalTickets}
+            isLoading={isLoading}
+            emphasis
+          />
+          <Stat label="Con turno" value={scheduled} isLoading={isLoading} />
+          <Stat label="Invitados" value={invited} isLoading={isLoading} />
+          <Stat
+            label="Administrativo"
+            value={administrative}
+            isLoading={isLoading}
+          />
+          <Stat
+            label="DNI no encontrado"
+            value={unregistered}
+            isLoading={isLoading}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Totem-Analytics/TotemReportDashboardContainer.tsx
+++ b/src/components/Totem-Analytics/TotemReportDashboardContainer.tsx
@@ -1,17 +1,18 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import {
-  ClipboardList,
-  Database,
-  Download,
-  Ticket,
-  UserCheck,
-  UserRoundPlus,
-  Users,
-} from "lucide-react";
+import { Database, Download, Ticket } from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { DateRangeFilter } from "@/components/Appointments-Analytics/DateRangeFilter";
+import {
+  CHART_AXIS_COLOR,
+  CHART_COLORS,
+  CHART_GRID_COLOR,
+  formatNumber,
+} from "@/components/Appointments-Analytics/chartTheme";
+import { ChartTooltip } from "@/components/Appointments-Analytics/ChartTooltip";
+import { TotemActivitySummary } from "./TotemActivitySummary";
+import { UnregisteredResolutionFunnel } from "./UnregisteredResolutionFunnel";
 import {
   useTotemAnalyticsReport,
   useTotemPatientRegistrationStats,
@@ -49,50 +50,41 @@ interface TotemReportDashboardContainerProps {
   showHeader?: boolean;
 }
 
-interface TotemMetricCardProps {
-  title: string;
-  value: number | string;
-  description: string;
-  icon: ReactNode;
-}
-
-const numberFormatter = new Intl.NumberFormat("es-AR");
 const TOTEM_OPERATION_START_DATE = "2026-04-06";
 const TOTEM_OPERATION_START_LABEL = "6 abr 2026";
 
 const todayDateString = () => format(new Date(), "yyyy-MM-dd");
 
-const isSundayDateString = (date: string) =>
-  new Date(`${date}T00:00:00`).getDay() === 0;
+// Normaliza cualquier fecha a YYYY-MM-DD para que los cruces por fecha entre
+// fuentes distintas (turnos, cola, historia clínica) hagan match aunque una
+// venga con hora/ISO completo.
+const dayKey = (date: string) => date.slice(0, 10);
+
+const parseTotemDate = (date: string) => new Date(`${dayKey(date)}T00:00:00`);
+
+const isSundayDateString = (date: string) => parseTotemDate(date).getDay() === 0;
 
 const sumBy = <T,>(items: T[], getValue: (item: T) => number) =>
   items.reduce((total, item) => total + getValue(item), 0);
+
+interface DailyTotalItem {
+  date: string;
+  total: number;
+}
+
+const sumDailyWithoutSunday = (items?: DailyTotalItem[]) =>
+  (items ?? [])
+    .filter((item) => !isSundayDateString(item.date))
+    .reduce((total, item) => total + item.total, 0);
+
+const toDayKeyMap = (items?: DailyTotalItem[]) =>
+  new Map((items ?? []).map((item) => [dayKey(item.date), item.total]));
 
 const maxDateString = (first: string, second: string) =>
   first > second ? first : second;
 
 const escapeCsvValue = (value: string | number) =>
   `"${String(value).replace(/"/g, '""')}"`;
-
-const TotemMetricCard = ({
-  title,
-  value,
-  description,
-  icon,
-}: TotemMetricCardProps) => (
-  <Card className="overflow-hidden border-border/70">
-    <CardContent className="flex items-start justify-between gap-4 p-5">
-      <div className="space-y-1">
-        <p className="text-sm font-medium text-muted-foreground">{title}</p>
-        <p className="text-3xl font-semibold tracking-tight">
-          {typeof value === "number" ? numberFormatter.format(value) : value}
-        </p>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-      <div className="rounded-xl bg-primary/10 p-3 text-primary">{icon}</div>
-    </CardContent>
-  </Card>
-);
 
 export function TotemReportDashboardContainer({
   showHeader = true,
@@ -151,58 +143,23 @@ export function TotemReportDashboardContainer({
     [visibleDailyItems]
   );
 
+  // Embudo de no registrados: todo recalculado sobre los días visibles (sin
+  // domingos) para que detectados/resueltos/pendientes/tasa cierren entre sí.
+  const unregisteredFunnel = useMemo(() => {
+    const summary = reportQuery.data?.unregistered;
+    const detected = sumDailyWithoutSunday(summary?.dailyDetected);
+    const resolved = sumDailyWithoutSunday(summary?.dailyResolved);
+    const createdNew = sumDailyWithoutSunday(summary?.dailyCreated);
+    const linkedExisting = sumDailyWithoutSunday(summary?.dailyLinkedExisting);
+    const pending = Math.max(0, detected - resolved);
+    const resolutionRate = detected
+      ? Math.round((resolved / detected) * 100)
+      : 0;
+    return { detected, resolved, createdNew, linkedExisting, pending, resolutionRate };
+  }, [reportQuery.data]);
+
   const dailyResolvedMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.unregistered.dailyResolved?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
-    [reportQuery.data]
-  );
-
-  const dailyCreatedMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.unregistered.dailyCreated?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
-    [reportQuery.data]
-  );
-
-  const dailyLinkedExistingMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.unregistered.dailyLinkedExisting?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
-    [reportQuery.data]
-  );
-
-  const dailyTotemCreatedMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.registrations?.dailyCreated?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
-    [reportQuery.data]
-  );
-
-  const dailyTotemLinkedExistingMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.registrations?.dailyLinkedExisting?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
+    () => toDayKeyMap(reportQuery.data?.unregistered.dailyResolved),
     [reportQuery.data]
   );
 
@@ -210,25 +167,24 @@ export function TotemReportDashboardContainer({
     () =>
       new Map(
         patientRegistrationsQuery.data?.daily.map((item) => [
-          item.date,
+          dayKey(item.date),
           item.usersCreated,
         ]) ?? []
       ),
     [patientRegistrationsQuery.data]
   );
 
-  const dailyPatientProfilesCreatedMap = useMemo(
-    () =>
-      new Map(
-        patientRegistrationsQuery.data?.daily.map((item) => [
-          item.date,
-          item.patientsCreated,
-        ]) ?? []
-      ),
-    [patientRegistrationsQuery.data]
+  const dailyTotemCreatedMap = useMemo(
+    () => toDayKeyMap(reportQuery.data?.registrations?.dailyCreated),
+    [reportQuery.data]
   );
 
-  const visibleRealRegistrationsTotal = useMemo(
+  const dailyTotemLinkedExistingMap = useMemo(
+    () => toDayKeyMap(reportQuery.data?.registrations?.dailyLinkedExisting),
+    [reportQuery.data]
+  );
+
+  const visibleNewPatientsTotal = useMemo(
     () => sumBy(visibleRegistrationDailyItems, (item) => item.usersCreated),
     [visibleRegistrationDailyItems]
   );
@@ -241,11 +197,10 @@ export function TotemReportDashboardContainer({
   const registrationTrendData = useMemo(
     () =>
       visibleRegistrationDailyItems.map((item) => ({
-        ...item,
-        label: format(new Date(`${item.date}T00:00:00`), "d MMM", {
-          locale: es,
-        }),
-        trazadosTotem: dailyTotemCreatedMap.get(item.date) ?? 0,
+        label: format(parseTotemDate(item.date), "d MMM", { locale: es }),
+        usersCreated: item.usersCreated,
+        patientsCreated: item.patientsCreated,
+        trazadosTotem: dailyTotemCreatedMap.get(dayKey(item.date)) ?? 0,
       })),
     [dailyTotemCreatedMap, visibleRegistrationDailyItems]
   );
@@ -254,100 +209,13 @@ export function TotemReportDashboardContainer({
     () =>
       visibleDailyItems.map((item) => ({
         ...item,
-        label: format(new Date(`${item.date}T00:00:00`), "d MMM", {
-          locale: es,
-        }),
+        label: format(parseTotemDate(item.date), "d MMM", { locale: es }),
       })),
     [visibleDailyItems]
   );
 
-  const visibleResolvedTicketsTotal = useMemo(
-    () => sumBy(visibleDailyItems, (item) => dailyResolvedMap.get(item.date) ?? 0),
-    [dailyResolvedMap, visibleDailyItems]
-  );
-
-  const visibleTotemCreatedTotal = useMemo(
-    () =>
-      sumBy(visibleDailyItems, (item) => dailyTotemCreatedMap.get(item.date) ?? 0),
-    [dailyTotemCreatedMap, visibleDailyItems]
-  );
-
-  const realRegistrationsValue: number | string =
-    patientRegistrationsQuery.isLoading
-      ? "..."
-      : patientRegistrationsQuery.data
-        ? visibleRealRegistrationsTotal
-        : "Sin dato";
-
-  const realRegistrationsDescription = patientRegistrationsQuery.data
-    ? `Fuente users.createdAt. Fichas paciente: ${numberFormatter.format(
-        visiblePatientProfilesTotal
-      )}.`
-    : patientRegistrationsQuery.isError
-      ? "No se pudo consultar Historia Clínica; no usa el conteo técnico del Totem."
-      : "Altas reales del sistema asociadas al circuito operativo del Totem.";
-
-  const cards = reportQuery.data
-    ? [
-        {
-          title: "Tickets Totem",
-          value: visibleOverview.totalTickets,
-          description:
-            dateFrom === TOTEM_OPERATION_START_DATE && dateTo === todayDateString()
-              ? "Total desde instalación hasta hoy, sin domingos en detalle."
-              : "Interacciones iniciadas desde el tótem en el rango visible.",
-          icon: <Ticket className="h-5 w-5" />,
-        },
-        {
-          title: "Con turno",
-          value: visibleOverview.scheduled,
-          description: "Pacientes registrados con turno previo.",
-          icon: <UserCheck className="h-5 w-5" />,
-        },
-        {
-          title: "Invitados",
-          value: visibleOverview.invited,
-          description: "Turnos de invitados que hicieron check-in en tótem.",
-          icon: <Users className="h-5 w-5" />,
-        },
-        {
-          title: "Trámite administrativo",
-          value: visibleOverview.administrative,
-          description: "Tickets administrativos originados en el tótem.",
-          icon: <ClipboardList className="h-5 w-5" />,
-        },
-        {
-          title: "DNI no encontrado",
-          value: visibleOverview.unregistered,
-          description: "Casos detectados por el tótem fuera del sistema.",
-          icon: <UserRoundPlus className="h-5 w-5" />,
-        },
-        {
-          title: "No registrados resueltos",
-          value: visibleResolvedTicketsTotal,
-          description: "Tickets del rango que ya quedaron vinculados o dados de alta.",
-          icon: <UserCheck className="h-5 w-5" />,
-        },
-        {
-          title: "No registrados pendientes",
-          value: reportQuery.data.unregistered.pendingTickets,
-          description: "Tickets del rango que todavía siguen sin resolución.",
-          icon: <ClipboardList className="h-5 w-5" />,
-        },
-        {
-          title: "Altas nuevas en sistema",
-          value: realRegistrationsValue,
-          description: realRegistrationsDescription,
-          icon: <Database className="h-5 w-5" />,
-        },
-        {
-          title: "Altas trazadas por Totem",
-          value: visibleTotemCreatedTotal,
-          description: "Conteo técnico de cola; no es la fuente del KPI principal.",
-          icon: <UserRoundPlus className="h-5 w-5" />,
-        },
-      ]
-    : [];
+  const isFullRange =
+    dateFrom === TOTEM_OPERATION_START_DATE && dateTo === todayDateString();
 
   const handleExportCsv = () => {
     if (!reportQuery.data) {
@@ -364,57 +232,54 @@ export function TotemReportDashboardContainer({
       ["Invitados", visibleOverview.invited],
       ["Trámite administrativo", visibleOverview.administrative],
       ["DNI no encontrado", visibleOverview.unregistered],
-      ["No registrados resueltos", visibleResolvedTicketsTotal],
-      ["No registrados pendientes", reportQuery.data.unregistered.pendingTickets],
+      ["Resueltos", unregisteredFunnel.resolved],
+      ["Pendientes", unregisteredFunnel.pending],
+      ["Nuevos pacientes", unregisteredFunnel.createdNew],
+      ["Vinculados a paciente existente", unregisteredFunnel.linkedExisting],
       [
         "Altas nuevas en sistema",
-        patientRegistrationsQuery.data ? visibleRealRegistrationsTotal : "Sin dato",
+        patientRegistrationsQuery.data ? visibleNewPatientsTotal : "Sin dato",
       ],
       [
-        "Fichas pacientes creadas",
+        "Fichas de paciente creadas",
         patientRegistrationsQuery.data ? visiblePatientProfilesTotal : "Sin dato",
-      ],
-      [
-        "Altas trazadas por Totem",
-        visibleTotemCreatedTotal,
       ],
       [],
       ["Detalle diario"],
       [
         "Fecha",
-        "Tickets Totem",
+        "Total",
         "Con turno",
         "Invitados",
-        "Trámite administrativo",
+        "Administrativo",
         "DNI no encontrado",
-        "Resueltos ese día",
-        "Altas reales sistema ese día",
-        "Fichas pacientes ese día",
-        "Altas trazadas Totem ese día",
-        "Vinculados Totem ese día",
+        "Resueltos",
+        "Altas sistema",
+        "Trazadas Totem",
+        "Vinculados Totem",
       ],
-      ...visibleDailyItems.map((item) => [
-        item.date,
-        item.totalTickets,
-        item.scheduled,
-        item.invited,
-        item.administrative,
-        item.unregistered,
-        dailyResolvedMap.get(item.date) ?? 0,
-        dailyRealUsersCreatedMap.get(item.date) ?? 0,
-        dailyPatientProfilesCreatedMap.get(item.date) ?? 0,
-        dailyTotemCreatedMap.get(item.date) ?? 0,
-        dailyTotemLinkedExistingMap.get(item.date) ?? 0,
-      ]),
+      ...visibleDailyItems.map((item) => {
+        const key = dayKey(item.date);
+        return [
+          item.date,
+          item.totalTickets,
+          item.scheduled,
+          item.invited,
+          item.administrative,
+          item.unregistered,
+          dailyResolvedMap.get(key) ?? 0,
+          dailyRealUsersCreatedMap.get(key) ?? 0,
+          dailyTotemCreatedMap.get(key) ?? 0,
+          dailyTotemLinkedExistingMap.get(key) ?? 0,
+        ];
+      }),
     ];
 
     const csvContent = csvRows
       .map((row) => row.map(escapeCsvValue).join(","))
       .join("\n");
 
-    const blob = new Blob([csvContent], {
-      type: "text/csv;charset=utf-8;",
-    });
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
@@ -425,8 +290,14 @@ export function TotemReportDashboardContainer({
     URL.revokeObjectURL(url);
   };
 
+  const newPatientsValue: number | string = patientRegistrationsQuery.isLoading
+    ? "…"
+    : patientRegistrationsQuery.data
+      ? visibleNewPatientsTotal
+      : "Sin dato";
+
   return (
-    <div className={`space-y-8 ${showHeader ? "p-6" : ""}`}>
+    <div className={`space-y-7 ${showHeader ? "p-6" : ""}`}>
       {showHeader && (
         <PageHeader
           breadcrumbItems={[
@@ -435,96 +306,127 @@ export function TotemReportDashboardContainer({
             { label: "Totem" },
           ]}
           title="Reporte Totem"
-          description="Seguimiento diario de tickets iniciados en el tótem y resolución de pacientes no registrados."
+          description="Seguimiento diario de tickets del tótem y resolución de pacientes no registrados."
           icon={<Ticket className="h-6 w-6" />}
         />
       )}
 
-      <div className="flex flex-col gap-5 rounded-2xl border bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 p-5 text-white shadow-sm md:p-6">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold">Filtros del reporte Totem</h2>
-            <p className="max-w-3xl text-sm text-slate-200">
-              Operativo desde {TOTEM_OPERATION_START_LABEL}. Las altas reales se
-              leen desde Historia Clínica (`users.createdAt`) porque hoy todo
-              ingreso pasa por el circuito Totem. Los domingos se ocultan del
-              detalle y exportación.
-            </p>
+      <div className="flex flex-col gap-4 rounded-2xl border bg-card p-5">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Período
+            </label>
+            <DateRangeFilter
+              from={dateFrom}
+              to={dateTo}
+              minDate={TOTEM_OPERATION_START_DATE}
+              maxDate={todayDateString()}
+              onRangeChange={handleRangeChange}
+            />
           </div>
-          <div className="flex flex-col gap-2">
+
+          <div className="flex flex-wrap gap-2">
             <Button
               type="button"
-              variant="secondary"
+              variant="outline"
               size="sm"
-              className="w-full bg-white text-slate-950 hover:bg-slate-100 xl:w-auto"
               onClick={handleInstallToToday}
             >
-              Desde instalación hasta hoy
+              Desde la instalación
             </Button>
-            <div className="[&_button]:border-white/20 [&_button]:bg-white/10 [&_button]:text-white [&_button:hover]:bg-white/20">
-              <DateRangeFilter
-                from={dateFrom}
-                to={dateTo}
-                minDate={TOTEM_OPERATION_START_DATE}
-                maxDate={todayDateString()}
-                onRangeChange={handleRangeChange}
-              />
-            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleExportCsv}
+              disabled={!reportQuery.data}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Exportar CSV
+            </Button>
           </div>
         </div>
 
-        <div className="flex flex-col gap-3 border-t border-white/10 pt-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            <Badge className="bg-white text-slate-950 hover:bg-white">
-              Base Totem: ticket iniciado
-            </Badge>
-            <Badge className="border-white/30 bg-white/10 text-white hover:bg-white/10">
-              Altas reales: users.createdAt
-            </Badge>
-            <Badge className="border-white/30 bg-white/10 text-white hover:bg-white/10">
-              {format(new Date(`${dateFrom}T00:00:00`), "d MMM yyyy", {
-                locale: es,
-              })}{" "}
-              -{" "}
-              {format(new Date(`${dateTo}T00:00:00`), "d MMM yyyy", {
-                locale: es,
-              })}
-            </Badge>
-          </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full border-white/25 bg-transparent text-white hover:bg-white hover:text-slate-950 md:w-auto"
-            onClick={handleExportCsv}
-            disabled={!reportQuery.data}
-          >
-            <Download className="mr-2 h-4 w-4" />
-            Exportar CSV
-          </Button>
+        <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+          <Badge variant="secondary">
+            {format(parseTotemDate(dateFrom), "d MMM yyyy", { locale: es })} —{" "}
+            {format(parseTotemDate(dateTo), "d MMM yyyy", { locale: es })}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            El tótem opera desde el {TOTEM_OPERATION_START_LABEL}. No se muestran
+            los domingos.
+          </span>
         </div>
       </div>
 
-      {reportQuery.isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {Array.from({ length: 9 }).map((_, index) => (
-            <Skeleton key={index} className="h-32 rounded-2xl" />
-          ))}
-        </div>
-      ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {cards.map((card) => (
-            <TotemMetricCard key={card.title} {...card} />
-          ))}
-        </div>
-      )}
+      <TotemActivitySummary
+        totalTickets={visibleOverview.totalTickets}
+        scheduled={visibleOverview.scheduled}
+        invited={visibleOverview.invited}
+        administrative={visibleOverview.administrative}
+        unregistered={visibleOverview.unregistered}
+        isLoading={reportQuery.isLoading}
+      />
 
-      <div className="grid gap-7 xl:grid-cols-2">
-        <Card className="overflow-hidden border-emerald-100/80 bg-gradient-to-br from-emerald-50 via-white to-slate-50">
-          <CardHeader>
-            <CardTitle>Tendencia de altas reales</CardTitle>
+      <div className="grid gap-6 xl:grid-cols-[1.5fr,1fr]">
+        <UnregisteredResolutionFunnel
+          detected={unregisteredFunnel.detected}
+          resolved={unregisteredFunnel.resolved}
+          createdNew={unregisteredFunnel.createdNew}
+          linkedExisting={unregisteredFunnel.linkedExisting}
+          pending={unregisteredFunnel.pending}
+          resolutionRate={unregisteredFunnel.resolutionRate}
+          isLoading={reportQuery.isLoading}
+        />
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Altas de pacientes</CardTitle>
             <CardDescription>
-              Alta en sistema por día operativo; fuente principal: users.createdAt.
+              {isFullRange
+                ? "Pacientes dados de alta desde la instalación."
+                : "Pacientes dados de alta en el período."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-xl bg-primary/10 p-3 text-primary">
+                <Database className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Pacientes nuevos registrados
+                </p>
+                <p className="text-3xl font-bold leading-none">
+                  {typeof newPatientsValue === "number"
+                    ? formatNumber(newPatientsValue)
+                    : newPatientsValue}
+                </p>
+              </div>
+            </div>
+            {patientRegistrationsQuery.isError ? (
+              <p className="text-xs text-muted-foreground">
+                No se pudo consultar el dato de altas en este momento.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Fichas de paciente creadas:{" "}
+                {patientRegistrationsQuery.data
+                  ? formatNumber(visiblePatientProfilesTotal)
+                  : "—"}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Altas de pacientes por día</CardTitle>
+            <CardDescription>
+              Pacientes nuevos registrados en el sistema por día.
             </CardDescription>
           </CardHeader>
           <CardContent className="h-[320px]">
@@ -532,11 +434,11 @@ export function TotemReportDashboardContainer({
               <Skeleton className="h-full w-full" />
             ) : patientRegistrationsQuery.isError ? (
               <div className="flex h-full items-center justify-center px-8 text-center text-sm text-muted-foreground">
-                No se pudo consultar Historia Clínica para graficar altas reales.
+                No se pudo consultar el dato de altas.
               </div>
             ) : !registrationTrendData.length ? (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Sin altas nuevas para el rango seleccionado.
+                Sin altas nuevas para el período seleccionado.
               </div>
             ) : (
               <ResponsiveContainer width="100%" height="100%">
@@ -544,35 +446,48 @@ export function TotemReportDashboardContainer({
                   data={registrationTrendData}
                   margin={{ top: 10, right: 16, left: -18, bottom: 12 }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                  <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
-                  <Tooltip />
-                  <Legend verticalAlign="top" height={32} />
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={CHART_GRID_COLOR}
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={{ stroke: CHART_GRID_COLOR }}
+                  />
+                  <YAxis
+                    allowDecimals={false}
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip content={<ChartTooltip />} />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
                   <Line
                     type="monotone"
                     dataKey="usersCreated"
-                    name="Altas sistema"
-                    stroke="#059669"
-                    strokeWidth={3}
-                    dot={{ r: 4 }}
-                    activeDot={{ r: 6 }}
+                    name="Altas en sistema"
+                    stroke={CHART_COLORS.green}
+                    strokeWidth={2}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="patientsCreated"
-                    name="Fichas paciente"
-                    stroke="#2563EB"
+                    name="Fichas de paciente"
+                    stroke={CHART_COLORS.blue}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="trazadosTotem"
-                    name="Trazadas por Totem"
-                    stroke="#F97316"
+                    name="Altas vía tótem"
+                    stroke={CHART_COLORS.orange}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -580,11 +495,11 @@ export function TotemReportDashboardContainer({
           </CardContent>
         </Card>
 
-        <Card className="overflow-hidden">
-          <CardHeader>
-            <CardTitle>Tendencia de tickets Totem</CardTitle>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Tickets del tótem por día</CardTitle>
             <CardDescription>
-              Volumen diario por origen para comparar demanda contra altas nuevas.
+              Volumen diario de tickets según su tipo.
             </CardDescription>
           </CardHeader>
           <CardContent className="h-[320px]">
@@ -592,7 +507,7 @@ export function TotemReportDashboardContainer({
               <Skeleton className="h-full w-full" />
             ) : !ticketTrendData.length ? (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Sin tickets para el rango seleccionado.
+                Sin tickets para el período seleccionado.
               </div>
             ) : (
               <ResponsiveContainer width="100%" height="100%">
@@ -600,35 +515,48 @@ export function TotemReportDashboardContainer({
                   data={ticketTrendData}
                   margin={{ top: 10, right: 16, left: -18, bottom: 12 }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                  <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
-                  <Tooltip />
-                  <Legend verticalAlign="top" height={32} />
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={CHART_GRID_COLOR}
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={{ stroke: CHART_GRID_COLOR }}
+                  />
+                  <YAxis
+                    allowDecimals={false}
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip content={<ChartTooltip />} />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
                   <Line
                     type="monotone"
                     dataKey="totalTickets"
                     name="Tickets"
                     stroke="#0F172A"
-                    strokeWidth={3}
-                    dot={{ r: 4 }}
-                    activeDot={{ r: 6 }}
+                    strokeWidth={2.5}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="scheduled"
                     name="Con turno"
-                    stroke="#16A34A"
+                    stroke={CHART_COLORS.green}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="invited"
                     name="Invitados"
-                    stroke="#2563EB"
+                    stroke={CHART_COLORS.blue}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
@@ -636,15 +564,15 @@ export function TotemReportDashboardContainer({
                     name="Administrativo"
                     stroke="#64748B"
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="unregistered"
                     name="DNI no encontrado"
-                    stroke="#F97316"
+                    stroke={CHART_COLORS.orange}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -653,17 +581,19 @@ export function TotemReportDashboardContainer({
         </Card>
       </div>
 
-      <div className="grid gap-7 xl:grid-cols-[1.6fr,1fr]">
-        <Card className="overflow-hidden">
-          <CardHeader>
-            <CardTitle>Detalle diario del Totem</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0">
-            {!visibleDailyItems.length ? (
-              <div className="text-sm text-muted-foreground">
-                Sin tickets del tótem para el rango seleccionado.
-              </div>
-            ) : (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Detalle diario del tótem</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {reportQuery.isLoading ? (
+            <Skeleton className="h-64 w-full" />
+          ) : !visibleDailyItems.length ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Sin tickets del tótem para el período seleccionado.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -680,163 +610,53 @@ export function TotemReportDashboardContainer({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {visibleDailyItems.map((item) => (
-                    <TableRow key={item.date}>
-                      <TableCell className="font-medium">
-                        {format(new Date(`${item.date}T00:00:00`), "EEE d MMM", {
-                          locale: es,
-                        })}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.totalTickets)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.scheduled)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.invited)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.administrative)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.unregistered)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(dailyResolvedMap.get(item.date) ?? 0)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(
-                          dailyRealUsersCreatedMap.get(item.date) ?? 0
-                        )}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(
-                          dailyTotemCreatedMap.get(item.date) ?? 0
-                        )}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(
-                          dailyTotemLinkedExistingMap.get(item.date) ?? 0
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {visibleDailyItems.map((item) => {
+                    const key = dayKey(item.date);
+                    return (
+                      <TableRow key={item.date}>
+                        <TableCell className="font-medium capitalize">
+                          {format(parseTotemDate(item.date), "EEE d MMM", {
+                            locale: es,
+                          })}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.totalTickets)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.scheduled)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.invited)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.administrative)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.unregistered)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(dailyResolvedMap.get(key) ?? 0)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(dailyRealUsersCreatedMap.get(key) ?? 0)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(dailyTotemCreatedMap.get(key) ?? 0)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(
+                            dailyTotemLinkedExistingMap.get(key) ?? 0
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="overflow-hidden">
-          <CardHeader>
-            <CardTitle>Resolución de no registrados</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4 pt-0">
-            {reportQuery.data ? (
-              <>
-                <div className="rounded-xl border bg-muted/30 p-4">
-                  <div className="text-sm font-medium">Tasa de resolución</div>
-                  <div className="mt-2 text-3xl font-semibold tracking-tight">
-                    {reportQuery.data.unregistered.resolutionRate.toFixed(2)}%
-                  </div>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Calculada sobre tickets detectados en el rango filtrado.
-                  </p>
-                </div>
-
-                <div className="rounded-xl border border-emerald-100 bg-emerald-50/60 p-4">
-                  <div className="text-sm font-medium">
-                    Trazabilidad técnica de altas
-                  </div>
-                  <div className="mt-2 text-3xl font-semibold tracking-tight text-emerald-700">
-                    {numberFormatter.format(visibleTotemCreatedTotal)}
-                  </div>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Eventos de cola que quedaron asociados al alta. Puede ser menor
-                    que las altas reales del sistema.
-                  </p>
-                  <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-                    <span>
-                      Invitados:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow?.invited ?? 0
-                      )}
-                    </span>
-                    <span>
-                      DNI no encontrado:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow
-                          ?.unregistered ??
-                          reportQuery.data.unregistered.createdPatientsInRange ??
-                          0
-                      )}
-                    </span>
-                    <span>
-                      Administrativo:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow
-                          ?.administrative ?? 0
-                      )}
-                    </span>
-                    <span>
-                      Con turno:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow?.scheduled ??
-                          0
-                      )}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  {reportQuery.data.unregistered.dailyDetected
-                    .filter((item) => !isSundayDateString(item.date))
-                    .map((item) => (
-                      <div
-                        key={item.date}
-                        className="rounded-xl border px-4 py-3"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="text-sm font-medium">
-                            {format(
-                              new Date(`${item.date}T00:00:00`),
-                              "EEEE d MMM",
-                              {
-                                locale: es,
-                              }
-                            )}
-                          </span>
-                          <Badge variant="secondary">
-                            {numberFormatter.format(item.total)} detectados
-                          </Badge>
-                        </div>
-                        <div className="mt-2 text-xs text-muted-foreground">
-                          {numberFormatter.format(
-                            dailyResolvedMap.get(item.date) ?? 0
-                          )}{" "}
-                          resueltos con fecha ese día.{" "}
-                          {numberFormatter.format(
-                            dailyCreatedMap.get(item.date) ?? 0
-                          )}{" "}
-                          fueron altas técnicas desde DNI no encontrado y{" "}
-                          {numberFormatter.format(
-                            dailyLinkedExistingMap.get(item.date) ?? 0
-                          )}{" "}
-                          fueron vinculaciones a pacientes existentes.
-                        </div>
-                      </div>
-                    ))}
-                </div>
-              </>
-            ) : (
-              <div className="text-sm text-muted-foreground">
-                Sin información disponible para el rango seleccionado.
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/Totem-Analytics/UnregisteredResolutionFunnel.tsx
+++ b/src/components/Totem-Analytics/UnregisteredResolutionFunnel.tsx
@@ -1,0 +1,140 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronRight, UserPlus, Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatNumber } from "@/components/Appointments-Analytics/chartTheme";
+
+interface UnregisteredResolutionFunnelProps {
+  detected: number;
+  resolved: number;
+  createdNew: number;
+  linkedExisting: number;
+  pending: number;
+  resolutionRate: number;
+  isLoading: boolean;
+}
+
+function Step({
+  label,
+  value,
+  share,
+  tone,
+  isLoading,
+}: {
+  label: string;
+  value: number;
+  share?: string;
+  tone: "neutral" | "green" | "amber";
+  isLoading: boolean;
+}) {
+  const valueColor = {
+    neutral: "text-slate-900",
+    green: "text-green-700",
+    amber: "text-amber-700",
+  }[tone];
+
+  return (
+    <div className="min-w-[120px] flex-1 px-2 py-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {isLoading ? (
+        <Skeleton className="mt-1 h-8 w-16" />
+      ) : (
+        <div className="mt-0.5 flex items-baseline gap-2">
+          <span className={cn("text-3xl font-bold leading-none", valueColor)}>
+            {formatNumber(value)}
+          </span>
+          {share && (
+            <span className="text-sm font-medium text-muted-foreground">
+              {share}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function UnregisteredResolutionFunnel({
+  detected,
+  resolved,
+  createdNew,
+  linkedExisting,
+  pending,
+  resolutionRate,
+  isLoading,
+}: UnregisteredResolutionFunnelProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">
+          Resolución de DNI no encontrado
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-col gap-2 rounded-xl border bg-muted/30 p-3 md:flex-row md:items-center md:gap-1">
+          <Step
+            label="Detectados"
+            value={detected}
+            tone="neutral"
+            isLoading={isLoading}
+          />
+          <ChevronRight className="hidden h-5 w-5 shrink-0 self-center text-muted-foreground/40 md:block" />
+          <Step
+            label="Resueltos"
+            value={resolved}
+            share={`${formatNumber(resolutionRate)}%`}
+            tone="green"
+            isLoading={isLoading}
+          />
+          <ChevronRight className="hidden h-5 w-5 shrink-0 self-center text-muted-foreground/40 md:block" />
+          <Step
+            label="Pendientes"
+            value={pending}
+            tone="amber"
+            isLoading={isLoading}
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex items-center gap-3 rounded-xl border border-green-100 bg-green-50/60 px-4 py-3">
+            <div className="rounded-lg bg-green-100 p-2 text-green-700">
+              <UserPlus className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Nuevos pacientes
+              </p>
+              {isLoading ? (
+                <Skeleton className="mt-1 h-6 w-12" />
+              ) : (
+                <p className="text-xl font-bold text-green-700">
+                  {formatNumber(createdNew)}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 rounded-xl border border-blue-100 bg-blue-50/60 px-4 py-3">
+            <div className="rounded-lg bg-blue-100 p-2 text-blue-700">
+              <Link2 className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Vinculados a paciente existente
+              </p>
+              {isLoading ? (
+                <Skeleton className="mt-1 h-6 w-12" />
+              ) : (
+                <p className="text-xl font-bold text-blue-700">
+                  {formatNumber(linkedExisting)}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Resumen

Rediseño del tab **Totem** (en `/admin/reportes-turnos`) y corrección de los bugs que hacían que los datos no marcaran bien.

### Bugs corregidos

- **Domingos que aparecían:** el filtro usaba `new Date(\`${date}T00:00:00\`)`. Si la fecha venía con hora/ISO completo, el parseo rompía (`getDay()` → `NaN`) y el domingo no se filtraba. Ahora todas las fechas se normalizan con `dayKey` (`slice(0,10)`) antes de parsear.
- **Columnas del detalle diario que mostraban 0:** `Resueltos`, `Altas sistema`, `Trazadas Totem` y `Vinculados Totem` salen de arrays distintos (y de otra API), y se cruzaban por fecha con `.get(item.date)`. Si los formatos de fecha no eran idénticos, el match fallaba en silencio y mostraba 0. Ahora las keys de los maps **y** los lookups usan `dayKey`, así cada celda cruza bien.
- **Totales que no cuadraban:** `detectados / resueltos / pendientes / tasa` se recalculan sobre los días visibles (sin domingos) en vez de usar los crudos del backend (que incluían domingos).
- **"Vinculado" inconsistente:** se mezclaban dos fuentes (`unregistered.dailyLinkedExisting` y `registrations.dailyLinkedExisting`). El concepto se unifica en el embudo de resolución.

### Rediseño UX

- Header oscuro con gradiente → **filtros claros** (estilo del tab de Turnos): label "Período", "Desde la instalación", badge de rango, "Exportar CSV".
- **Resumen de actividad** del tótem (Tickets · Con turno · Invitados · Administrativo · DNI no encontrado).
- **Embudo de resolución de DNI no encontrado:** Detectados → Resueltos (Nuevos pacientes / Vinculados a existente) → Pendientes, con la tasa.
- **Altas de pacientes** en lenguaje claro (sin "users.createdAt" ni jerga técnica).
- Gráficos con `chartTheme` + `ChartTooltip` compartidos (tooltips en español).
- **Detalle diario** con las 10 columnas pedidas, cada una marcando su dato real.

No se tocaron hooks, endpoints ni tipos.

## Test plan

- [ ] `/admin/reportes-turnos` → tab Totem
- [ ] Verificar que **no aparecen domingos** en la tabla, gráficos ni CSV
- [ ] En el detalle diario, confirmar que Resueltos / Altas sistema / Trazadas Totem / Vinculados Totem **muestran valores reales** (no 0) cuando corresponde
- [ ] Embudo de no registrados: Detectados = Resueltos + Pendientes, y Resueltos ≈ Nuevos + Vinculados
- [ ] Exportar CSV y validar columnas
- [ ] `npm run type-check`, `npm run lint`, `npm run build` pasan

🤖 Generated with [Claude Code](https://claude.com/claude-code)