### PR TITLE
feat: promover rediseño de reportes de Turnos y Totem a main

### DIFF
--- a/src/api/Totem-Analytics/get-patient-registrations.action.ts
+++ b/src/api/Totem-Analytics/get-patient-registrations.action.ts
@@ -1,0 +1,22 @@
+import { apiIncorHC } from "@/services/axiosConfig";
+import {
+  TotemAnalyticsFilters,
+  TotemPatientRegistrationStats,
+} from "@/types/Totem-Analytics/TotemAnalytics";
+
+const buildPatientRegistrationParams = (filters: TotemAnalyticsFilters) => {
+  const params = new URLSearchParams();
+  params.set("dateFrom", filters.dateFrom);
+  params.set("dateTo", filters.dateTo);
+  return params;
+};
+
+export const getTotemPatientRegistrationStats = async (
+  filters: TotemAnalyticsFilters
+): Promise<TotemPatientRegistrationStats> => {
+  const { data } = await apiIncorHC.get<TotemPatientRegistrationStats>(
+    `/statistics/patient-registrations?${buildPatientRegistrationParams(filters).toString()}`
+  );
+
+  return data;
+};

--- a/src/api/Totem-Analytics/index.ts
+++ b/src/api/Totem-Analytics/index.ts
@@ -1,1 +1,2 @@
 export * from "./get-report.action";
+export * from "./get-patient-registrations.action";

--- a/src/components/Appointments-Analytics/AppointmentsManagementDashboardContainer.tsx
+++ b/src/components/Appointments-Analytics/AppointmentsManagementDashboardContainer.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { format, subMonths } from "date-fns";
-import { BarChart3, FilterX } from "lucide-react";
+import { BarChart3, X } from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { DoctorSelect } from "@/components/Appointments/Select/DoctorSelect";
 import { ConsultationTypeSelect } from "@/components/Appointments/Select/ConsultationTypeSelect";
@@ -11,6 +11,7 @@ import { ConsultationTypeVolumeChart } from "./ConsultationTypeVolumeChart";
 import { OriginMixChart } from "./OriginMixChart";
 import { DoctorOriginChart } from "./DoctorOriginChart";
 import { CancellationTrendChart } from "./CancellationTrendChart";
+import { formatNumber } from "./chartTheme";
 import {
   useAppointmentsAnalyticsByConsultationType,
   useAppointmentsAnalyticsByDoctor,
@@ -19,13 +20,60 @@ import {
   useAppointmentsAnalyticsOverview,
   useOverturnAnalyticsOverview,
 } from "@/hooks/Appointments-Analytics";
-import { AppointmentOrigin } from "@/types/Appointment/Appointment";
+import { useDoctors } from "@/hooks/Doctor/useDoctors";
+import { useConsultationTypes } from "@/hooks/ConsultationType";
+import { formatDoctorName } from "@/common/helpers/helpers";
+import {
+  AppointmentOrigin,
+  AppointmentOriginLabels,
+} from "@/types/Appointment/Appointment";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 
 interface AppointmentsManagementDashboardContainerProps {
   showHeader?: boolean;
+}
+
+function FilterField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function ActiveFilterChip({
+  label,
+  value,
+  onRemove,
+}: {
+  label: string;
+  value: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border bg-background py-1 pl-3 pr-1.5 text-sm">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="font-medium text-foreground">{value}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Quitar filtro ${label}`}
+        className="ml-0.5 flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  );
 }
 
 export function AppointmentsManagementDashboardContainer({
@@ -36,7 +84,9 @@ export function AppointmentsManagementDashboardContainer({
   );
   const [dateTo, setDateTo] = useState(() => format(new Date(), "yyyy-MM-dd"));
   const [doctorId, setDoctorId] = useState<number | undefined>(undefined);
-  const [consultationTypeId, setConsultationTypeId] = useState<number | undefined>(undefined);
+  const [consultationTypeId, setConsultationTypeId] = useState<
+    number | undefined
+  >(undefined);
   const [origin, setOrigin] = useState<AppointmentOrigin | undefined>(undefined);
 
   const filters = {
@@ -54,7 +104,20 @@ export function AppointmentsManagementDashboardContainer({
   const cancellationsQuery = useAppointmentsAnalyticsCancellations(filters);
   const overturnOverviewQuery = useOverturnAnalyticsOverview(filters);
 
-  const isSummaryLoading = overviewQuery.isLoading || overturnOverviewQuery.isLoading;
+  const { doctors } = useDoctors({ auth: true, fetchDoctors: true });
+  const { consultationTypes } = useConsultationTypes(
+    doctorId ? { doctorId } : undefined
+  );
+
+  const selectedDoctor = doctorId
+    ? doctors.find((d) => Number(d.userId) === doctorId)
+    : undefined;
+  const selectedType = consultationTypeId
+    ? consultationTypes.find((t) => t.id === consultationTypeId)
+    : undefined;
+
+  const isSummaryLoading =
+    overviewQuery.isLoading || overturnOverviewQuery.isLoading;
   const hasActiveFilters = !!doctorId || !!consultationTypeId || !!origin;
 
   const clearNonDateFilters = () => {
@@ -63,8 +126,14 @@ export function AppointmentsManagementDashboardContainer({
     setOrigin(undefined);
   };
 
+  const overturnByDoctor = overturnOverviewQuery.data?.byDoctor ?? [];
+  const maxOverturn = overturnByDoctor.reduce(
+    (max, item) => Math.max(max, item.total),
+    0
+  );
+
   return (
-    <div className={`space-y-8 ${showHeader ? "p-6" : ""}`}>
+    <div className={`space-y-7 ${showHeader ? "p-6" : ""}`}>
       {showHeader && (
         <PageHeader
           breadcrumbItems={[
@@ -77,14 +146,8 @@ export function AppointmentsManagementDashboardContainer({
         />
       )}
 
-      <div className="flex flex-col gap-5 rounded-2xl border bg-card p-5 md:p-6">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold">Filtros</h2>
-            <p className="text-sm text-muted-foreground">
-              Acotá el análisis por período, médico, tipo de turno y origen.
-            </p>
-          </div>
+      <div className="flex flex-col gap-4 rounded-2xl border bg-card p-5">
+        <FilterField label="Período">
           <DateRangeFilter
             from={dateFrom}
             to={dateTo}
@@ -93,46 +156,68 @@ export function AppointmentsManagementDashboardContainer({
               setDateTo(nextTo);
             }}
           />
-        </div>
+        </FilterField>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <DoctorSelect
-            value={doctorId}
-            onValueChange={setDoctorId}
-            placeholder="Todos los médicos"
-            allowClear
-          />
-          <ConsultationTypeSelect
-            value={consultationTypeId}
-            onValueChange={setConsultationTypeId}
-            placeholder="Todos los tipos"
-          />
-          <OriginSelect value={origin} onValueChange={setOrigin} />
+          <FilterField label="Médico">
+            <DoctorSelect
+              value={doctorId}
+              onValueChange={setDoctorId}
+              placeholder="Todos los médicos"
+              allowClear
+            />
+          </FilterField>
+          <FilterField label="Tipo de turno">
+            <ConsultationTypeSelect
+              value={consultationTypeId}
+              onValueChange={setConsultationTypeId}
+              placeholder="Todos los tipos"
+            />
+          </FilterField>
+          <FilterField label="Origen">
+            <OriginSelect value={origin} onValueChange={setOrigin} />
+          </FilterField>
         </div>
 
-        <div className="flex flex-col gap-3 border-t pt-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            {doctorId && <Badge variant="secondary">Médico filtrado</Badge>}
-            {consultationTypeId && <Badge variant="secondary">Tipo filtrado</Badge>}
-            {origin && <Badge variant="secondary">Origen filtrado</Badge>}
-            {!hasActiveFilters && (
-              <span className="text-sm text-muted-foreground">
-                Sin filtros adicionales activos.
-              </span>
+        {hasActiveFilters && (
+          <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+            <span className="text-xs font-medium text-muted-foreground">
+              Filtros activos:
+            </span>
+            {doctorId && (
+              <ActiveFilterChip
+                label="Médico"
+                value={
+                  selectedDoctor ? formatDoctorName(selectedDoctor) : "Seleccionado"
+                }
+                onRemove={() => setDoctorId(undefined)}
+              />
             )}
+            {consultationTypeId && (
+              <ActiveFilterChip
+                label="Tipo"
+                value={selectedType ? selectedType.name : "Seleccionado"}
+                onRemove={() => setConsultationTypeId(undefined)}
+              />
+            )}
+            {origin && (
+              <ActiveFilterChip
+                label="Origen"
+                value={AppointmentOriginLabels[origin]}
+                onRemove={() => setOrigin(undefined)}
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={clearNonDateFilters}
+              className="ml-auto h-8 text-muted-foreground hover:text-foreground"
+            >
+              Limpiar todo
+            </Button>
           </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={clearNonDateFilters}
-            disabled={!hasActiveFilters}
-            className="w-full md:w-auto"
-          >
-            <FilterX className="mr-2 h-4 w-4" />
-            Limpiar filtros
-          </Button>
-        </div>
+        )}
       </div>
 
       <ManagementSummaryCards
@@ -141,7 +226,7 @@ export function AppointmentsManagementDashboardContainer({
         isLoading={isSummaryLoading}
       />
 
-      <div className="grid gap-7 xl:grid-cols-2">
+      <div className="grid gap-6 xl:grid-cols-2">
         <ConsultationTypeVolumeChart
           data={byTypeQuery.data}
           isLoading={byTypeQuery.isLoading}
@@ -152,7 +237,7 @@ export function AppointmentsManagementDashboardContainer({
         />
       </div>
 
-      <div className="grid gap-7 xl:grid-cols-2">
+      <div className="grid gap-6 xl:grid-cols-2">
         <CancellationTrendChart
           data={cancellationsQuery.data?.trend}
           isLoading={cancellationsQuery.isLoading}
@@ -163,21 +248,35 @@ export function AppointmentsManagementDashboardContainer({
         />
       </div>
 
-      <Card className="overflow-hidden">
-        <CardHeader>
-          <CardTitle>Sobreturnos por médico</CardTitle>
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Sobreturnos por médico</CardTitle>
         </CardHeader>
-        <CardContent className="pt-0">
-          {!overturnOverviewQuery.data?.byDoctor?.length ? (
-            <div className="text-sm text-muted-foreground">
+        <CardContent>
+          {!overturnByDoctor.length ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
               Sin sobreturnos para el período seleccionado.
             </div>
           ) : (
             <div className="space-y-3">
-              {overturnOverviewQuery.data.byDoctor.slice(0, 8).map((item) => (
-                <div key={item.id ?? item.label} className="flex items-center justify-between rounded-lg border px-4 py-3">
-                  <span className="text-sm font-medium">{item.label}</span>
-                  <span className="text-sm text-muted-foreground">{item.total}</span>
+              {overturnByDoctor.slice(0, 8).map((item) => (
+                <div key={item.id ?? item.label} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">{item.label}</span>
+                    <span className="tabular-nums text-muted-foreground">
+                      {formatNumber(item.total)}
+                    </span>
+                  </div>
+                  <div className="h-2 overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-purple-500"
+                      style={{
+                        width: `${
+                          maxOverturn ? (item.total / maxOverturn) * 100 : 0
+                        }%`,
+                      }}
+                    />
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/components/Appointments-Analytics/CancellationTrendChart.tsx
+++ b/src/components/Appointments-Analytics/CancellationTrendChart.tsx
@@ -1,7 +1,14 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   CartesianGrid,
+  Legend,
   Line,
   LineChart,
   ResponsiveContainer,
@@ -12,6 +19,8 @@ import {
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { AppointmentsAnalyticsTrendPoint } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import { CHART_AXIS_COLOR, CHART_COLORS, CHART_GRID_COLOR } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 interface Props {
   data?: AppointmentsAnalyticsTrendPoint[];
@@ -21,13 +30,16 @@ interface Props {
 export function CancellationTrendChart({ data, isLoading }: Props) {
   const chartData = (data ?? []).map((item) => ({
     ...item,
-    bucketLabel: format(new Date(`${item.bucket}T00:00:00`), "MMM yyyy", { locale: es }),
+    bucketLabel: format(new Date(`${item.bucket}T00:00:00`), "MMM yyyy", {
+      locale: es,
+    }),
   }));
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Evolución de cancelaciones</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Evolución de cancelaciones</CardTitle>
+        <CardDescription>Quién cancela los turnos a lo largo del tiempo.</CardDescription>
       </CardHeader>
       <CardContent className="h-[320px]">
         {isLoading ? (
@@ -39,12 +51,37 @@ export function CancellationTrendChart({ data, isLoading }: Props) {
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartData} margin={{ top: 10, right: 16, left: -16, bottom: 12 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="bucketLabel" />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Line type="monotone" dataKey="cancelledByPatient" stroke="#EA580C" strokeWidth={2} name="Paciente" />
-              <Line type="monotone" dataKey="cancelledBySecretary" stroke="#DC2626" strokeWidth={2} name="Secretaría" />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART_GRID_COLOR} />
+              <XAxis
+                dataKey="bucketLabel"
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={{ stroke: CHART_GRID_COLOR }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip content={<ChartTooltip />} />
+              <Legend iconType="plainline" wrapperStyle={{ fontSize: 12 }} />
+              <Line
+                type="monotone"
+                dataKey="cancelledByPatient"
+                stroke={CHART_COLORS.orange}
+                strokeWidth={2}
+                dot={false}
+                name="Paciente"
+              />
+              <Line
+                type="monotone"
+                dataKey="cancelledBySecretary"
+                stroke={CHART_COLORS.red}
+                strokeWidth={2}
+                dot={false}
+                name="Secretaría"
+              />
             </LineChart>
           </ResponsiveContainer>
         )}

--- a/src/components/Appointments-Analytics/ChartTooltip.tsx
+++ b/src/components/Appointments-Analytics/ChartTooltip.tsx
@@ -1,0 +1,49 @@
+import { formatNumber } from "./chartTheme";
+
+interface ChartTooltipEntry {
+  name?: string;
+  value?: number | string;
+  color?: string;
+  dataKey?: string | number;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  payload?: ChartTooltipEntry[];
+  label?: string | number;
+}
+
+export function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 shadow-md">
+      {label !== undefined && label !== "" && (
+        <p className="mb-1 text-xs font-medium text-foreground">{label}</p>
+      )}
+      <div className="space-y-0.5">
+        {payload.map((entry, index) => (
+          <div
+            key={`${entry.dataKey ?? entry.name ?? index}`}
+            className="flex items-center justify-between gap-4 text-xs"
+          >
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              {entry.color && (
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+              )}
+              {entry.name}
+            </span>
+            <span className="font-semibold text-foreground">
+              {typeof entry.value === "number"
+                ? formatNumber(entry.value)
+                : entry.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Appointments-Analytics/ConsultationTypeVolumeChart.tsx
+++ b/src/components/Appointments-Analytics/ConsultationTypeVolumeChart.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Bar,
@@ -10,6 +16,8 @@ import {
   YAxis,
 } from "recharts";
 import { AppointmentsAnalyticsGroupedItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import { CHART_AXIS_COLOR, CHART_COLORS, CHART_GRID_COLOR } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 interface Props {
   data?: AppointmentsAnalyticsGroupedItem[];
@@ -24,8 +32,9 @@ export function ConsultationTypeVolumeChart({ data, isLoading }: Props) {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Mix por tipo de turno</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Mix por tipo de turno</CardTitle>
+        <CardDescription>Volumen de turnos por cada tipo de consulta.</CardDescription>
       </CardHeader>
       <CardContent className="h-[320px]">
         {isLoading ? (
@@ -37,11 +46,25 @@ export function ConsultationTypeVolumeChart({ data, isLoading }: Props) {
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 10, right: 16, left: -16, bottom: 32 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="name" angle={-20} textAnchor="end" interval={0} height={72} />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Bar dataKey="total" fill="#2563EB" radius={[6, 6, 0, 0]} />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART_GRID_COLOR} />
+              <XAxis
+                dataKey="name"
+                angle={-20}
+                textAnchor="end"
+                interval={0}
+                height={72}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={{ stroke: CHART_GRID_COLOR }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip cursor={{ fill: "rgba(37, 99, 235, 0.06)" }} content={<ChartTooltip />} />
+              <Bar dataKey="total" name="Turnos" fill={CHART_COLORS.blue} radius={[6, 6, 0, 0]} maxBarSize={48} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/src/components/Appointments-Analytics/DateRangeFilter.tsx
+++ b/src/components/Appointments-Analytics/DateRangeFilter.tsx
@@ -17,6 +17,8 @@ interface DateRangeFilterProps {
   from: string;
   to: string;
   onRangeChange: (from: string, to: string) => void;
+  minDate?: string;
+  maxDate?: string;
 }
 
 type Preset = {
@@ -55,20 +57,45 @@ const presets: Preset[] = [
   },
 ];
 
-export function DateRangeFilter({ from, to, onRangeChange }: DateRangeFilterProps) {
+const parseDateOnly = (value?: string) =>
+  value ? new Date(`${value}T00:00:00`) : undefined;
+
+const clampDate = (date: Date, minDate?: Date, maxDate?: Date) => {
+  if (minDate && date < minDate) return minDate;
+  if (maxDate && date > maxDate) return maxDate;
+  return date;
+};
+
+export function DateRangeFilter({
+  from,
+  to,
+  onRangeChange,
+  minDate,
+  maxDate,
+}: DateRangeFilterProps) {
   const [calendarOpen, setCalendarOpen] = useState(false);
+  const minDateValue = parseDateOnly(minDate);
+  const maxDateValue = parseDateOnly(maxDate);
 
   const dateRange: DateRange = {
     from: from ? new Date(`${from}T00:00:00`) : undefined,
     to: to ? new Date(`${to}T00:00:00`) : undefined,
   };
 
+  const emitRangeChange = (nextFrom: Date, nextTo: Date) => {
+    const normalizedFrom = clampDate(nextFrom, minDateValue, maxDateValue);
+    const normalizedTo = clampDate(nextTo, minDateValue, maxDateValue);
+    const [safeFrom, safeTo] =
+      normalizedFrom <= normalizedTo
+        ? [normalizedFrom, normalizedTo]
+        : [normalizedTo, normalizedFrom];
+
+    onRangeChange(format(safeFrom, "yyyy-MM-dd"), format(safeTo, "yyyy-MM-dd"));
+  };
+
   const handlePreset = (preset: Preset) => {
     const { from: presetFrom, to: presetTo } = preset.getValue();
-    onRangeChange(
-      format(presetFrom, "yyyy-MM-dd"),
-      format(presetTo, "yyyy-MM-dd")
-    );
+    emitRangeChange(presetFrom, presetTo);
   };
 
   const handleCalendarSelect = (range: DateRange | undefined) => {
@@ -77,7 +104,10 @@ export function DateRangeFilter({ from, to, onRangeChange }: DateRangeFilterProp
     const newFrom = format(range.from, "yyyy-MM-dd");
     const newTo = range.to ? format(range.to, "yyyy-MM-dd") : newFrom;
 
-    onRangeChange(newFrom, newTo);
+    emitRangeChange(
+      new Date(`${newFrom}T00:00:00`),
+      new Date(`${newTo}T00:00:00`)
+    );
 
     if (range.to) {
       setCalendarOpen(false);
@@ -93,18 +123,30 @@ export function DateRangeFilter({ from, to, onRangeChange }: DateRangeFilterProp
     return `${format(fromDate, "d MMM yyyy", { locale: es })} – ${format(toDate, "d MMM yyyy", { locale: es })}`;
   };
 
+  const isPresetActive = (preset: Preset) => {
+    const { from: presetFrom, to: presetTo } = preset.getValue();
+    return (
+      format(presetFrom, "yyyy-MM-dd") === from &&
+      format(presetTo, "yyyy-MM-dd") === to
+    );
+  };
+
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {presets.map((preset) => (
-        <Button
-          key={preset.label}
-          variant="outline"
-          size="sm"
-          onClick={() => handlePreset(preset)}
-        >
-          {preset.label}
-        </Button>
-      ))}
+      {presets.map((preset) => {
+        const active = isPresetActive(preset);
+        return (
+          <Button
+            key={preset.label}
+            variant={active ? "default" : "outline"}
+            size="sm"
+            aria-pressed={active}
+            onClick={() => handlePreset(preset)}
+          >
+            {preset.label}
+          </Button>
+        );
+      })}
 
       <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
         <PopoverTrigger asChild>
@@ -129,6 +171,12 @@ export function DateRangeFilter({ from, to, onRangeChange }: DateRangeFilterProp
             onSelect={handleCalendarSelect}
             numberOfMonths={2}
             locale={es}
+            disabled={(date) =>
+              Boolean(
+                (minDateValue && date < minDateValue) ||
+                  (maxDateValue && date > maxDateValue)
+              )
+            }
           />
         </PopoverContent>
       </Popover>

--- a/src/components/Appointments-Analytics/DoctorOriginChart.tsx
+++ b/src/components/Appointments-Analytics/DoctorOriginChart.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Bar,
@@ -11,7 +17,12 @@ import {
   YAxis,
 } from "recharts";
 import { AppointmentsAnalyticsDoctorItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
-import { AppointmentOrigin, AppointmentOriginLabels } from "@/types/Appointment/Appointment";
+import {
+  AppointmentOrigin,
+  AppointmentOriginLabels,
+} from "@/types/Appointment/Appointment";
+import { CHART_AXIS_COLOR, CHART_COLORS, CHART_GRID_COLOR } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 const ORIGINS = [
   AppointmentOrigin.SECRETARY,
@@ -21,10 +32,10 @@ const ORIGINS = [
 ];
 
 const ORIGIN_COLORS: Record<AppointmentOrigin, string> = {
-  [AppointmentOrigin.SECRETARY]: "#2563EB",
-  [AppointmentOrigin.WEB_PATIENT]: "#16A34A",
-  [AppointmentOrigin.WEB_GUEST]: "#EA580C",
-  [AppointmentOrigin.DOCTOR]: "#7C3AED",
+  [AppointmentOrigin.SECRETARY]: CHART_COLORS.blue,
+  [AppointmentOrigin.WEB_PATIENT]: CHART_COLORS.green,
+  [AppointmentOrigin.WEB_GUEST]: CHART_COLORS.orange,
+  [AppointmentOrigin.DOCTOR]: CHART_COLORS.purple,
 };
 
 interface Props {
@@ -49,8 +60,9 @@ export function DoctorOriginChart({ data, isLoading }: Props) {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Origen por médico</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Origen por médico</CardTitle>
+        <CardDescription>Cómo se reparten los turnos de cada médico según su origen.</CardDescription>
       </CardHeader>
       <CardContent className="h-[360px]">
         {isLoading ? (
@@ -62,11 +74,25 @@ export function DoctorOriginChart({ data, isLoading }: Props) {
         ) : (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 10, right: 16, left: -16, bottom: 48 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="name" angle={-20} textAnchor="end" interval={0} height={86} />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Legend />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART_GRID_COLOR} />
+              <XAxis
+                dataKey="name"
+                angle={-20}
+                textAnchor="end"
+                interval={0}
+                height={86}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={{ stroke: CHART_GRID_COLOR }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip cursor={{ fill: "rgba(100, 116, 139, 0.06)" }} content={<ChartTooltip />} />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
               {ORIGINS.map((origin) => (
                 <Bar
                   key={origin}
@@ -74,6 +100,7 @@ export function DoctorOriginChart({ data, isLoading }: Props) {
                   stackId="origin"
                   fill={ORIGIN_COLORS[origin]}
                   name={AppointmentOriginLabels[origin]}
+                  maxBarSize={48}
                 />
               ))}
             </BarChart>

--- a/src/components/Appointments-Analytics/ManagementSummaryCards.tsx
+++ b/src/components/Appointments-Analytics/ManagementSummaryCards.tsx
@@ -1,10 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CalendarDays, CheckCircle2, Clock3, RotateCcw, XCircle } from "lucide-react";
+import { ChevronRight, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 import {
   AppointmentsAnalyticsOverview,
   OverturnAnalyticsOverview,
 } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
+import { formatNumber } from "./chartTheme";
 
 interface Props {
   overview?: AppointmentsAnalyticsOverview;
@@ -12,39 +14,129 @@ interface Props {
   isLoading: boolean;
 }
 
-function StatCard({
-  title,
+type StepTone = "neutral" | "blue" | "green" | "red";
+
+const TONE_STYLES: Record<StepTone, { value: string; share: string }> = {
+  neutral: { value: "text-slate-900", share: "text-slate-500" },
+  blue: { value: "text-blue-700", share: "text-blue-600" },
+  green: { value: "text-green-700", share: "text-green-600" },
+  red: { value: "text-red-700", share: "text-red-600" },
+};
+
+function FunnelStep({
+  label,
   value,
-  icon,
+  share,
+  tone,
   isLoading,
 }: {
-  title: string;
-  value: string | number;
-  icon: React.ReactNode;
+  label: string;
+  value: number;
+  share?: string;
+  tone: StepTone;
   isLoading: boolean;
 }) {
+  const styles = TONE_STYLES[tone];
+
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
-        {icon}
-      </CardHeader>
-      <CardContent>
-        {isLoading ? <Skeleton className="h-8 w-20" /> : <div className="text-2xl font-bold">{value}</div>}
-      </CardContent>
-    </Card>
+    <div className="min-w-[120px] flex-1 px-2 py-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {isLoading ? (
+        <Skeleton className="mt-1 h-8 w-16" />
+      ) : (
+        <div className="mt-0.5 flex items-baseline gap-2">
+          <span className={cn("text-3xl font-bold leading-none", styles.value)}>
+            {formatNumber(value)}
+          </span>
+          {share && (
+            <span className={cn("text-sm font-medium", styles.share)}>{share}</span>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
-export function ManagementSummaryCards({ overview, overturnOverview, isLoading }: Props) {
+function StepArrow() {
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
-      <StatCard title="Turnos creados" value={overview?.totalCreated ?? 0} icon={<Clock3 className="h-5 w-5 text-slate-500" />} isLoading={isLoading} />
-      <StatCard title="Turnos agendados" value={overview?.totalScheduled ?? 0} icon={<CalendarDays className="h-5 w-5 text-blue-600" />} isLoading={isLoading} />
-      <StatCard title="Completados" value={overview?.totalCompleted ?? 0} icon={<CheckCircle2 className="h-5 w-5 text-green-600" />} isLoading={isLoading} />
-      <StatCard title="Cancelados" value={overview?.totalCancelled ?? 0} icon={<XCircle className="h-5 w-5 text-red-600" />} isLoading={isLoading} />
-      <StatCard title="Tasa cancelación" value={`${overview?.cancellationRate ?? 0}%`} icon={<RotateCcw className="h-5 w-5 text-amber-600" />} isLoading={isLoading} />
-      <StatCard title="Sobreturnos" value={overturnOverview?.totalCreated ?? 0} icon={<CalendarDays className="h-5 w-5 text-purple-600" />} isLoading={isLoading} />
-    </div>
+    <ChevronRight className="hidden h-5 w-5 shrink-0 self-center text-muted-foreground/40 md:block" />
+  );
+}
+
+export function ManagementSummaryCards({
+  overview,
+  overturnOverview,
+  isLoading,
+}: Props) {
+  const created = overview?.totalCreated ?? 0;
+  const scheduled = overview?.totalScheduled ?? 0;
+  const completed = overview?.totalCompleted ?? 0;
+  const cancelled = overview?.totalCancelled ?? 0;
+  const cancellationRate = overview?.cancellationRate ?? 0;
+  const overturns = overturnOverview?.totalCreated ?? 0;
+
+  const share = (value: number): string | undefined => {
+    if (!created) return undefined;
+    return `${Math.round((value / created) * 100)}%`;
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Recorrido de los turnos</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+          <div className="flex flex-1 flex-col gap-2 rounded-xl border bg-muted/30 p-3 md:flex-row md:items-center md:gap-1">
+            <FunnelStep
+              label="Creados"
+              value={created}
+              tone="neutral"
+              isLoading={isLoading}
+            />
+            <StepArrow />
+            <FunnelStep
+              label="Agendados"
+              value={scheduled}
+              share={share(scheduled)}
+              tone="blue"
+              isLoading={isLoading}
+            />
+            <StepArrow />
+            <FunnelStep
+              label="Completados"
+              value={completed}
+              share={share(completed)}
+              tone="green"
+              isLoading={isLoading}
+            />
+            <div className="hidden w-px self-stretch bg-border md:block" />
+            <FunnelStep
+              label="Cancelados"
+              value={cancelled}
+              share={`${formatNumber(cancellationRate)}%`}
+              tone="red"
+              isLoading={isLoading}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-xl border border-purple-100 bg-purple-50/60 px-4 py-3 lg:w-48 lg:flex-col lg:items-start lg:justify-center">
+            <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-purple-700">
+              <Plus className="h-3.5 w-3.5" />
+              Sobreturnos
+            </div>
+            {isLoading ? (
+              <Skeleton className="h-8 w-12" />
+            ) : (
+              <span className="text-3xl font-bold leading-none text-purple-700">
+                {formatNumber(overturns)}
+              </span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/Appointments-Analytics/OriginMixChart.tsx
+++ b/src/components/Appointments-Analytics/OriginMixChart.tsx
@@ -1,31 +1,50 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
-  Cell,
-  Pie,
-  PieChart,
-  ResponsiveContainer,
-  Tooltip,
-} from "recharts";
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { AppointmentsAnalyticsOriginItem } from "@/types/Appointments-Analytics/AppointmentsAnalytics";
-
-const COLORS = ["#2563EB", "#16A34A", "#EA580C", "#7C3AED", "#DC2626"];
+import {
+  AppointmentOrigin,
+  AppointmentOriginLabels,
+} from "@/types/Appointment/Appointment";
+import { CHART_PALETTE, formatNumber } from "./chartTheme";
+import { ChartTooltip } from "./ChartTooltip";
 
 interface Props {
   data?: AppointmentsAnalyticsOriginItem[];
   isLoading: boolean;
 }
 
+function resolveOriginName(item: AppointmentsAnalyticsOriginItem): string {
+  if (item.origin && AppointmentOriginLabels[item.origin]) {
+    return AppointmentOriginLabels[item.origin];
+  }
+  const fromLabel = AppointmentOriginLabels[item.label as AppointmentOrigin];
+  if (fromLabel) {
+    return fromLabel;
+  }
+  return item.label || "Sin origen";
+}
+
 export function OriginMixChart({ data, isLoading }: Props) {
-  const chartData = (data ?? []).map((item) => ({
-    name: item.label,
+  const chartData = (data ?? []).map((item, index) => ({
+    name: resolveOriginName(item),
     value: item.total,
+    color: CHART_PALETTE[index % CHART_PALETTE.length],
   }));
+
+  const total = chartData.reduce((sum, item) => sum + item.value, 0);
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Origen de turnos</CardTitle>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Origen de turnos</CardTitle>
+        <CardDescription>Por dónde se generan los turnos del período.</CardDescription>
       </CardHeader>
       <CardContent className="h-[320px]">
         {isLoading ? (
@@ -35,16 +54,54 @@ export function OriginMixChart({ data, isLoading }: Props) {
             Sin datos para el período seleccionado.
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie data={chartData} dataKey="value" nameKey="name" innerRadius={64} outerRadius={100} paddingAngle={2}>
-                {chartData.map((entry, index) => (
-                  <Cell key={entry.name} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="flex h-full flex-col items-center gap-4 sm:flex-row">
+            <div className="h-[200px] w-full sm:h-full sm:flex-1">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    dataKey="value"
+                    nameKey="name"
+                    innerRadius={60}
+                    outerRadius={96}
+                    paddingAngle={2}
+                  >
+                    {chartData.map((entry) => (
+                      <Cell key={entry.name} fill={entry.color} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<ChartTooltip />} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+
+            <ul className="w-full space-y-2 sm:w-44">
+              {chartData.map((entry) => {
+                const percent = total
+                  ? Math.round((entry.value / total) * 100)
+                  : 0;
+                return (
+                  <li
+                    key={entry.name}
+                    className="flex items-center justify-between gap-2 text-sm"
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: entry.color }}
+                      />
+                      <span className="truncate text-muted-foreground">
+                        {entry.name}
+                      </span>
+                    </span>
+                    <span className="shrink-0 font-medium tabular-nums">
+                      {formatNumber(entry.value)} · {percent}%
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/Appointments-Analytics/chartTheme.ts
+++ b/src/components/Appointments-Analytics/chartTheme.ts
@@ -1,0 +1,22 @@
+export const CHART_COLORS = {
+  blue: "#2563EB",
+  green: "#16A34A",
+  orange: "#EA580C",
+  purple: "#7C3AED",
+  red: "#DC2626",
+  amber: "#D97706",
+} as const;
+
+export const CHART_PALETTE = [
+  CHART_COLORS.blue,
+  CHART_COLORS.green,
+  CHART_COLORS.orange,
+  CHART_COLORS.purple,
+  CHART_COLORS.red,
+];
+
+export const CHART_GRID_COLOR = "#E2E8F0";
+export const CHART_AXIS_COLOR = "#64748B";
+
+export const formatNumber = (value: number): string =>
+  value.toLocaleString("es-AR");

--- a/src/components/Totem-Analytics/TotemActivitySummary.tsx
+++ b/src/components/Totem-Analytics/TotemActivitySummary.tsx
@@ -1,0 +1,84 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { formatNumber } from "@/components/Appointments-Analytics/chartTheme";
+
+interface TotemActivitySummaryProps {
+  totalTickets: number;
+  scheduled: number;
+  invited: number;
+  administrative: number;
+  unregistered: number;
+  isLoading: boolean;
+}
+
+function Stat({
+  label,
+  value,
+  isLoading,
+  emphasis = false,
+}: {
+  label: string;
+  value: number;
+  isLoading: boolean;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="min-w-[110px] flex-1 px-3 py-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {isLoading ? (
+        <Skeleton className="mt-1 h-8 w-16" />
+      ) : (
+        <p
+          className={cn(
+            "mt-0.5 font-bold leading-none",
+            emphasis ? "text-3xl text-slate-900" : "text-2xl text-slate-700"
+          )}
+        >
+          {formatNumber(value)}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function TotemActivitySummary({
+  totalTickets,
+  scheduled,
+  invited,
+  administrative,
+  unregistered,
+  isLoading,
+}: TotemActivitySummaryProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Actividad del tótem</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col divide-y rounded-xl border bg-muted/30 md:flex-row md:divide-x md:divide-y-0">
+          <Stat
+            label="Tickets"
+            value={totalTickets}
+            isLoading={isLoading}
+            emphasis
+          />
+          <Stat label="Con turno" value={scheduled} isLoading={isLoading} />
+          <Stat label="Invitados" value={invited} isLoading={isLoading} />
+          <Stat
+            label="Administrativo"
+            value={administrative}
+            isLoading={isLoading}
+          />
+          <Stat
+            label="DNI no encontrado"
+            value={unregistered}
+            isLoading={isLoading}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Totem-Analytics/TotemReportDashboardContainer.tsx
+++ b/src/components/Totem-Analytics/TotemReportDashboardContainer.tsx
@@ -1,17 +1,22 @@
-import { useMemo, useState, type ReactNode } from "react";
-import { format, subDays } from "date-fns";
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import {
-  ClipboardList,
-  Download,
-  Ticket,
-  UserCheck,
-  UserRoundPlus,
-  Users,
-} from "lucide-react";
+import { Database, Download, Ticket } from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { DateRangeFilter } from "@/components/Appointments-Analytics/DateRangeFilter";
-import { useTotemAnalyticsReport } from "@/hooks/Totem-Analytics";
+import {
+  CHART_AXIS_COLOR,
+  CHART_COLORS,
+  CHART_GRID_COLOR,
+  formatNumber,
+} from "@/components/Appointments-Analytics/chartTheme";
+import { ChartTooltip } from "@/components/Appointments-Analytics/ChartTooltip";
+import { TotemActivitySummary } from "./TotemActivitySummary";
+import { UnregisteredResolutionFunnel } from "./UnregisteredResolutionFunnel";
+import {
+  useTotemAnalyticsReport,
+  useTotemPatientRegistrationStats,
+} from "@/hooks/Totem-Analytics";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -45,193 +50,172 @@ interface TotemReportDashboardContainerProps {
   showHeader?: boolean;
 }
 
-interface TotemMetricCardProps {
-  title: string;
-  value: number;
-  description: string;
-  icon: ReactNode;
+const TOTEM_OPERATION_START_DATE = "2026-04-06";
+const TOTEM_OPERATION_START_LABEL = "6 abr 2026";
+
+const todayDateString = () => format(new Date(), "yyyy-MM-dd");
+
+// Normaliza cualquier fecha a YYYY-MM-DD para que los cruces por fecha entre
+// fuentes distintas (turnos, cola, historia clínica) hagan match aunque una
+// venga con hora/ISO completo.
+const dayKey = (date: string) => date.slice(0, 10);
+
+const parseTotemDate = (date: string) => new Date(`${dayKey(date)}T00:00:00`);
+
+const isSundayDateString = (date: string) => parseTotemDate(date).getDay() === 0;
+
+const sumBy = <T,>(items: T[], getValue: (item: T) => number) =>
+  items.reduce((total, item) => total + getValue(item), 0);
+
+interface DailyTotalItem {
+  date: string;
+  total: number;
 }
 
-const numberFormatter = new Intl.NumberFormat("es-AR");
+const sumDailyWithoutSunday = (items?: DailyTotalItem[]) =>
+  (items ?? [])
+    .filter((item) => !isSundayDateString(item.date))
+    .reduce((total, item) => total + item.total, 0);
+
+const toDayKeyMap = (items?: DailyTotalItem[]) =>
+  new Map((items ?? []).map((item) => [dayKey(item.date), item.total]));
+
+const maxDateString = (first: string, second: string) =>
+  first > second ? first : second;
 
 const escapeCsvValue = (value: string | number) =>
   `"${String(value).replace(/"/g, '""')}"`;
 
-const TotemMetricCard = ({
-  title,
-  value,
-  description,
-  icon,
-}: TotemMetricCardProps) => (
-  <Card className="overflow-hidden border-border/70">
-    <CardContent className="flex items-start justify-between gap-4 p-5">
-      <div className="space-y-1">
-        <p className="text-sm font-medium text-muted-foreground">{title}</p>
-        <p className="text-3xl font-semibold tracking-tight">
-          {numberFormatter.format(value)}
-        </p>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-      <div className="rounded-xl bg-primary/10 p-3 text-primary">{icon}</div>
-    </CardContent>
-  </Card>
-);
-
 export function TotemReportDashboardContainer({
   showHeader = true,
 }: TotemReportDashboardContainerProps) {
-  const [dateFrom, setDateFrom] = useState(() =>
-    format(subDays(new Date(), 6), "yyyy-MM-dd")
-  );
-  const [dateTo, setDateTo] = useState(() => format(new Date(), "yyyy-MM-dd"));
+  const [dateFrom, setDateFrom] = useState(TOTEM_OPERATION_START_DATE);
+  const [dateTo, setDateTo] = useState(todayDateString);
 
   const reportQuery = useTotemAnalyticsReport({ dateFrom, dateTo });
+  const patientRegistrationsQuery = useTotemPatientRegistrationStats({
+    dateFrom,
+    dateTo,
+  });
+
+  const handleRangeChange = (nextFrom: string, nextTo: string) => {
+    const normalizedFrom = maxDateString(nextFrom, TOTEM_OPERATION_START_DATE);
+    const normalizedTo = maxDateString(nextTo, TOTEM_OPERATION_START_DATE);
+
+    if (normalizedFrom > normalizedTo) {
+      setDateFrom(normalizedTo);
+      setDateTo(normalizedTo);
+      return;
+    }
+
+    setDateFrom(normalizedFrom);
+    setDateTo(normalizedTo);
+  };
+
+  const handleInstallToToday = () => {
+    setDateFrom(TOTEM_OPERATION_START_DATE);
+    setDateTo(todayDateString());
+  };
+
+  const visibleDailyItems = useMemo(
+    () =>
+      reportQuery.data?.daily.filter((item) => !isSundayDateString(item.date)) ??
+      [],
+    [reportQuery.data]
+  );
+
+  const visibleRegistrationDailyItems = useMemo(
+    () =>
+      patientRegistrationsQuery.data?.daily.filter(
+        (item) => !isSundayDateString(item.date)
+      ) ?? [],
+    [patientRegistrationsQuery.data]
+  );
+
+  const visibleOverview = useMemo(
+    () => ({
+      totalTickets: sumBy(visibleDailyItems, (item) => item.totalTickets),
+      scheduled: sumBy(visibleDailyItems, (item) => item.scheduled),
+      invited: sumBy(visibleDailyItems, (item) => item.invited),
+      administrative: sumBy(visibleDailyItems, (item) => item.administrative),
+      unregistered: sumBy(visibleDailyItems, (item) => item.unregistered),
+    }),
+    [visibleDailyItems]
+  );
+
+  // Embudo de no registrados: todo recalculado sobre los días visibles (sin
+  // domingos) para que detectados/resueltos/pendientes/tasa cierren entre sí.
+  const unregisteredFunnel = useMemo(() => {
+    const summary = reportQuery.data?.unregistered;
+    const detected = sumDailyWithoutSunday(summary?.dailyDetected);
+    const resolved = sumDailyWithoutSunday(summary?.dailyResolved);
+    const createdNew = sumDailyWithoutSunday(summary?.dailyCreated);
+    const linkedExisting = sumDailyWithoutSunday(summary?.dailyLinkedExisting);
+    const pending = Math.max(0, detected - resolved);
+    const resolutionRate = detected
+      ? Math.round((resolved / detected) * 100)
+      : 0;
+    return { detected, resolved, createdNew, linkedExisting, pending, resolutionRate };
+  }, [reportQuery.data]);
 
   const dailyResolvedMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.unregistered.dailyResolved?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
+    () => toDayKeyMap(reportQuery.data?.unregistered.dailyResolved),
     [reportQuery.data]
   );
 
-  const dailyCreatedMap = useMemo(
+  const dailyRealUsersCreatedMap = useMemo(
     () =>
       new Map(
-        reportQuery.data?.unregistered.dailyCreated?.map((item) => [
-          item.date,
-          item.total,
+        patientRegistrationsQuery.data?.daily.map((item) => [
+          dayKey(item.date),
+          item.usersCreated,
         ]) ?? []
       ),
-    [reportQuery.data]
-  );
-
-  const dailyLinkedExistingMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.unregistered.dailyLinkedExisting?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
-    [reportQuery.data]
+    [patientRegistrationsQuery.data]
   );
 
   const dailyTotemCreatedMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.registrations?.dailyCreated?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
+    () => toDayKeyMap(reportQuery.data?.registrations?.dailyCreated),
     [reportQuery.data]
   );
 
   const dailyTotemLinkedExistingMap = useMemo(
-    () =>
-      new Map(
-        reportQuery.data?.registrations?.dailyLinkedExisting?.map((item) => [
-          item.date,
-          item.total,
-        ]) ?? []
-      ),
+    () => toDayKeyMap(reportQuery.data?.registrations?.dailyLinkedExisting),
     [reportQuery.data]
+  );
+
+  const visibleNewPatientsTotal = useMemo(
+    () => sumBy(visibleRegistrationDailyItems, (item) => item.usersCreated),
+    [visibleRegistrationDailyItems]
+  );
+
+  const visiblePatientProfilesTotal = useMemo(
+    () => sumBy(visibleRegistrationDailyItems, (item) => item.patientsCreated),
+    [visibleRegistrationDailyItems]
   );
 
   const registrationTrendData = useMemo(
     () =>
-      reportQuery.data?.registrations?.dailyCreated?.map((item) => ({
-        ...item,
-        label: format(new Date(`${item.date}T00:00:00`), "d MMM", {
-          locale: es,
-        }),
-        vinculados:
-          reportQuery.data?.registrations?.dailyLinkedExisting?.find(
-            (linked) => linked.date === item.date
-          )?.total ?? 0,
-      })) ?? [],
-    [reportQuery.data]
+      visibleRegistrationDailyItems.map((item) => ({
+        label: format(parseTotemDate(item.date), "d MMM", { locale: es }),
+        usersCreated: item.usersCreated,
+        patientsCreated: item.patientsCreated,
+        trazadosTotem: dailyTotemCreatedMap.get(dayKey(item.date)) ?? 0,
+      })),
+    [dailyTotemCreatedMap, visibleRegistrationDailyItems]
   );
 
   const ticketTrendData = useMemo(
     () =>
-      reportQuery.data?.daily.map((item) => ({
+      visibleDailyItems.map((item) => ({
         ...item,
-        label: format(new Date(`${item.date}T00:00:00`), "d MMM", {
-          locale: es,
-        }),
-      })) ?? [],
-    [reportQuery.data]
+        label: format(parseTotemDate(item.date), "d MMM", { locale: es }),
+      })),
+    [visibleDailyItems]
   );
 
-  const cards = reportQuery.data
-    ? [
-        {
-          title: "Tickets Totem",
-          value: reportQuery.data.overview.totalTickets,
-          description: "Interacciones iniciadas desde el tótem en el rango.",
-          icon: <Ticket className="h-5 w-5" />,
-        },
-        {
-          title: "Con turno",
-          value: reportQuery.data.overview.scheduled,
-          description: "Pacientes registrados con turno previo.",
-          icon: <UserCheck className="h-5 w-5" />,
-        },
-        {
-          title: "Invitados",
-          value: reportQuery.data.overview.invited,
-          description: "Turnos de invitados que hicieron check-in en tótem.",
-          icon: <Users className="h-5 w-5" />,
-        },
-        {
-          title: "Trámite administrativo",
-          value: reportQuery.data.overview.administrative,
-          description: "Tickets administrativos originados en el tótem.",
-          icon: <ClipboardList className="h-5 w-5" />,
-        },
-        {
-          title: "DNI no encontrado",
-          value: reportQuery.data.overview.unregistered,
-          description: "Casos detectados por el tótem fuera del sistema.",
-          icon: <UserRoundPlus className="h-5 w-5" />,
-        },
-        {
-          title: "No registrados resueltos",
-          value: reportQuery.data.unregistered.resolvedTickets,
-          description: "Tickets del rango que ya quedaron vinculados o dados de alta.",
-          icon: <UserCheck className="h-5 w-5" />,
-        },
-        {
-          title: "No registrados pendientes",
-          value: reportQuery.data.unregistered.pendingTickets,
-          description: "Tickets del rango que todavía siguen sin resolución.",
-          icon: <ClipboardList className="h-5 w-5" />,
-        },
-        {
-          title: "Pacientes nuevos desde Totem",
-          value:
-            reportQuery.data.registrations?.createdPatientsInRange ??
-            reportQuery.data.unregistered.createdPatientsInRange ??
-            0,
-          description: "Altas nuevas originadas por cualquier ticket del tótem.",
-          icon: <UserRoundPlus className="h-5 w-5" />,
-        },
-        {
-          title: "Vinculados desde Totem",
-          value:
-            reportQuery.data.registrations?.linkedExistingPatientsInRange ??
-            reportQuery.data.unregistered.linkedExistingPatientsInRange ??
-            0,
-          description: "Tickets del tótem asociados a pacientes existentes.",
-          icon: <UserRoundPlus className="h-5 w-5" />,
-        },
-      ]
-    : [];
+  const isFullRange =
+    dateFrom === TOTEM_OPERATION_START_DATE && dateTo === todayDateString();
 
   const handleExportCsv = () => {
     if (!reportQuery.data) {
@@ -243,64 +227,59 @@ export function TotemReportDashboardContainer({
       ["Desde", dateFrom, "Hasta", dateTo],
       [],
       ["Resumen"],
-      ["Tickets Totem", reportQuery.data.overview.totalTickets],
-      ["Con turno", reportQuery.data.overview.scheduled],
-      ["Invitados", reportQuery.data.overview.invited],
-      ["Trámite administrativo", reportQuery.data.overview.administrative],
-      ["DNI no encontrado", reportQuery.data.overview.unregistered],
-      ["No registrados resueltos", reportQuery.data.unregistered.resolvedTickets],
-      ["No registrados pendientes", reportQuery.data.unregistered.pendingTickets],
+      ["Tickets Totem", visibleOverview.totalTickets],
+      ["Con turno", visibleOverview.scheduled],
+      ["Invitados", visibleOverview.invited],
+      ["Trámite administrativo", visibleOverview.administrative],
+      ["DNI no encontrado", visibleOverview.unregistered],
+      ["Resueltos", unregisteredFunnel.resolved],
+      ["Pendientes", unregisteredFunnel.pending],
+      ["Nuevos pacientes", unregisteredFunnel.createdNew],
+      ["Vinculados a paciente existente", unregisteredFunnel.linkedExisting],
       [
-        "Pacientes nuevos desde Totem",
-        reportQuery.data.registrations?.createdPatientsInRange ??
-          reportQuery.data.unregistered.createdPatientsInRange ??
-          0,
+        "Altas nuevas en sistema",
+        patientRegistrationsQuery.data ? visibleNewPatientsTotal : "Sin dato",
       ],
       [
-        "Vinculados desde Totem",
-        reportQuery.data.registrations?.linkedExistingPatientsInRange ??
-          reportQuery.data.unregistered.linkedExistingPatientsInRange ??
-          0,
-      ],
-      [
-        "Pacientes nuevos desde DNI no encontrado",
-        reportQuery.data.unregistered.createdPatientsInRange ?? 0,
+        "Fichas de paciente creadas",
+        patientRegistrationsQuery.data ? visiblePatientProfilesTotal : "Sin dato",
       ],
       [],
       ["Detalle diario"],
       [
         "Fecha",
-        "Tickets Totem",
+        "Total",
         "Con turno",
         "Invitados",
-        "Trámite administrativo",
+        "Administrativo",
         "DNI no encontrado",
-        "Resueltos ese día",
-        "Pacientes nuevos Totem ese día",
-        "Vinculados Totem ese día",
-        "Pacientes nuevos desde DNI no encontrado ese día",
+        "Resueltos",
+        "Altas sistema",
+        "Trazadas Totem",
+        "Vinculados Totem",
       ],
-      ...reportQuery.data.daily.map((item) => [
-        item.date,
-        item.totalTickets,
-        item.scheduled,
-        item.invited,
-        item.administrative,
-        item.unregistered,
-        dailyResolvedMap.get(item.date) ?? 0,
-        dailyTotemCreatedMap.get(item.date) ?? 0,
-        dailyTotemLinkedExistingMap.get(item.date) ?? 0,
-        dailyCreatedMap.get(item.date) ?? 0,
-      ]),
+      ...visibleDailyItems.map((item) => {
+        const key = dayKey(item.date);
+        return [
+          item.date,
+          item.totalTickets,
+          item.scheduled,
+          item.invited,
+          item.administrative,
+          item.unregistered,
+          dailyResolvedMap.get(key) ?? 0,
+          dailyRealUsersCreatedMap.get(key) ?? 0,
+          dailyTotemCreatedMap.get(key) ?? 0,
+          dailyTotemLinkedExistingMap.get(key) ?? 0,
+        ];
+      }),
     ];
 
     const csvContent = csvRows
       .map((row) => row.map(escapeCsvValue).join(","))
       .join("\n");
 
-    const blob = new Blob([csvContent], {
-      type: "text/csv;charset=utf-8;",
-    });
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
@@ -311,8 +290,14 @@ export function TotemReportDashboardContainer({
     URL.revokeObjectURL(url);
   };
 
+  const newPatientsValue: number | string = patientRegistrationsQuery.isLoading
+    ? "…"
+    : patientRegistrationsQuery.data
+      ? visibleNewPatientsTotal
+      : "Sin dato";
+
   return (
-    <div className={`space-y-8 ${showHeader ? "p-6" : ""}`}>
+    <div className={`space-y-7 ${showHeader ? "p-6" : ""}`}>
       {showHeader && (
         <PageHeader
           breadcrumbItems={[
@@ -321,88 +306,139 @@ export function TotemReportDashboardContainer({
             { label: "Totem" },
           ]}
           title="Reporte Totem"
-          description="Seguimiento diario de tickets iniciados en el tótem y resolución de pacientes no registrados."
+          description="Seguimiento diario de tickets del tótem y resolución de pacientes no registrados."
           icon={<Ticket className="h-6 w-6" />}
         />
       )}
 
-      <div className="flex flex-col gap-5 rounded-2xl border bg-card p-5 md:p-6">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold">Filtros del reporte Totem</h2>
-            <p className="text-sm text-muted-foreground">
-              El detalle diario usa como base cada ticket iniciado en el tótem. Las
-              altas nuevas se miden para todo el circuito Totem y se desglosan por
-              origen del ticket.
-            </p>
+      <div className="flex flex-col gap-4 rounded-2xl border bg-card p-5">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">
+              Período
+            </label>
+            <DateRangeFilter
+              from={dateFrom}
+              to={dateTo}
+              minDate={TOTEM_OPERATION_START_DATE}
+              maxDate={todayDateString()}
+              onRangeChange={handleRangeChange}
+            />
           </div>
-          <DateRangeFilter
-            from={dateFrom}
-            to={dateTo}
-            onRangeChange={(nextFrom: string, nextTo: string) => {
-              setDateFrom(nextFrom);
-              setDateTo(nextTo);
-            }}
-          />
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleInstallToToday}
+            >
+              Desde la instalación
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleExportCsv}
+              disabled={!reportQuery.data}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Exportar CSV
+            </Button>
+          </div>
         </div>
 
-        <div className="flex flex-col gap-3 border-t pt-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap gap-2">
-            <Badge variant="secondary">
-              Base: ticket iniciado en tótem
-            </Badge>
-            <Badge variant="outline">
-              {format(new Date(`${dateFrom}T00:00:00`), "d MMM yyyy", {
-                locale: es,
-              })}{" "}
-              -{" "}
-              {format(new Date(`${dateTo}T00:00:00`), "d MMM yyyy", {
-                locale: es,
-              })}
-            </Badge>
-          </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full md:w-auto"
-            onClick={handleExportCsv}
-            disabled={!reportQuery.data}
-          >
-            <Download className="mr-2 h-4 w-4" />
-            Exportar CSV
-          </Button>
+        <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+          <Badge variant="secondary">
+            {format(parseTotemDate(dateFrom), "d MMM yyyy", { locale: es })} —{" "}
+            {format(parseTotemDate(dateTo), "d MMM yyyy", { locale: es })}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            El tótem opera desde el {TOTEM_OPERATION_START_LABEL}. No se muestran
+            los domingos.
+          </span>
         </div>
       </div>
 
-      {reportQuery.isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {Array.from({ length: 9 }).map((_, index) => (
-            <Skeleton key={index} className="h-32 rounded-2xl" />
-          ))}
-        </div>
-      ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {cards.map((card) => (
-            <TotemMetricCard key={card.title} {...card} />
-          ))}
-        </div>
-      )}
+      <TotemActivitySummary
+        totalTickets={visibleOverview.totalTickets}
+        scheduled={visibleOverview.scheduled}
+        invited={visibleOverview.invited}
+        administrative={visibleOverview.administrative}
+        unregistered={visibleOverview.unregistered}
+        isLoading={reportQuery.isLoading}
+      />
 
-      <div className="grid gap-7 xl:grid-cols-2">
-        <Card className="overflow-hidden border-emerald-100/80 bg-gradient-to-br from-emerald-50 via-white to-slate-50">
-          <CardHeader>
-            <CardTitle>Tendencia de altas nuevas</CardTitle>
+      <div className="grid gap-6 xl:grid-cols-[1.5fr,1fr]">
+        <UnregisteredResolutionFunnel
+          detected={unregisteredFunnel.detected}
+          resolved={unregisteredFunnel.resolved}
+          createdNew={unregisteredFunnel.createdNew}
+          linkedExisting={unregisteredFunnel.linkedExisting}
+          pending={unregisteredFunnel.pending}
+          resolutionRate={unregisteredFunnel.resolutionRate}
+          isLoading={reportQuery.isLoading}
+        />
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Altas de pacientes</CardTitle>
             <CardDescription>
-              Pacientes creados desde cualquier ticket iniciado en el tótem.
+              {isFullRange
+                ? "Pacientes dados de alta desde la instalación."
+                : "Pacientes dados de alta en el período."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-xl bg-primary/10 p-3 text-primary">
+                <Database className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Pacientes nuevos registrados
+                </p>
+                <p className="text-3xl font-bold leading-none">
+                  {typeof newPatientsValue === "number"
+                    ? formatNumber(newPatientsValue)
+                    : newPatientsValue}
+                </p>
+              </div>
+            </div>
+            {patientRegistrationsQuery.isError ? (
+              <p className="text-xs text-muted-foreground">
+                No se pudo consultar el dato de altas en este momento.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Fichas de paciente creadas:{" "}
+                {patientRegistrationsQuery.data
+                  ? formatNumber(visiblePatientProfilesTotal)
+                  : "—"}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Altas de pacientes por día</CardTitle>
+            <CardDescription>
+              Pacientes nuevos registrados en el sistema por día.
             </CardDescription>
           </CardHeader>
           <CardContent className="h-[320px]">
-            {reportQuery.isLoading ? (
+            {patientRegistrationsQuery.isLoading ? (
               <Skeleton className="h-full w-full" />
+            ) : patientRegistrationsQuery.isError ? (
+              <div className="flex h-full items-center justify-center px-8 text-center text-sm text-muted-foreground">
+                No se pudo consultar el dato de altas.
+              </div>
             ) : !registrationTrendData.length ? (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Sin altas nuevas para el rango seleccionado.
+                Sin altas nuevas para el período seleccionado.
               </div>
             ) : (
               <ResponsiveContainer width="100%" height="100%">
@@ -410,43 +446,48 @@ export function TotemReportDashboardContainer({
                   data={registrationTrendData}
                   margin={{ top: 10, right: 16, left: -18, bottom: 12 }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                  <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
-                  <Tooltip />
-                  <Legend verticalAlign="top" height={32} />
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={CHART_GRID_COLOR}
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={{ stroke: CHART_GRID_COLOR }}
+                  />
+                  <YAxis
+                    allowDecimals={false}
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip content={<ChartTooltip />} />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
                   <Line
                     type="monotone"
-                    dataKey="total"
-                    name="Nuevos Totem"
-                    stroke="#059669"
-                    strokeWidth={3}
-                    dot={{ r: 4 }}
-                    activeDot={{ r: 6 }}
+                    dataKey="usersCreated"
+                    name="Altas en sistema"
+                    stroke={CHART_COLORS.green}
+                    strokeWidth={2}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
-                    dataKey="invited"
-                    name="Invitados"
-                    stroke="#2563EB"
+                    dataKey="patientsCreated"
+                    name="Fichas de paciente"
+                    stroke={CHART_COLORS.blue}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
-                    dataKey="unregistered"
-                    name="DNI no encontrado"
-                    stroke="#F97316"
+                    dataKey="trazadosTotem"
+                    name="Altas vía tótem"
+                    stroke={CHART_COLORS.orange}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="administrative"
-                    name="Administrativo"
-                    stroke="#64748B"
-                    strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -454,11 +495,11 @@ export function TotemReportDashboardContainer({
           </CardContent>
         </Card>
 
-        <Card className="overflow-hidden">
-          <CardHeader>
-            <CardTitle>Tendencia de tickets Totem</CardTitle>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Tickets del tótem por día</CardTitle>
             <CardDescription>
-              Volumen diario por origen para comparar demanda contra altas nuevas.
+              Volumen diario de tickets según su tipo.
             </CardDescription>
           </CardHeader>
           <CardContent className="h-[320px]">
@@ -466,7 +507,7 @@ export function TotemReportDashboardContainer({
               <Skeleton className="h-full w-full" />
             ) : !ticketTrendData.length ? (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Sin tickets para el rango seleccionado.
+                Sin tickets para el período seleccionado.
               </div>
             ) : (
               <ResponsiveContainer width="100%" height="100%">
@@ -474,35 +515,48 @@ export function TotemReportDashboardContainer({
                   data={ticketTrendData}
                   margin={{ top: 10, right: 16, left: -18, bottom: 12 }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                  <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-                  <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
-                  <Tooltip />
-                  <Legend verticalAlign="top" height={32} />
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={CHART_GRID_COLOR}
+                  />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={{ stroke: CHART_GRID_COLOR }}
+                  />
+                  <YAxis
+                    allowDecimals={false}
+                    tick={{ fontSize: 12, fill: CHART_AXIS_COLOR }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <Tooltip content={<ChartTooltip />} />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
                   <Line
                     type="monotone"
                     dataKey="totalTickets"
                     name="Tickets"
                     stroke="#0F172A"
-                    strokeWidth={3}
-                    dot={{ r: 4 }}
-                    activeDot={{ r: 6 }}
+                    strokeWidth={2.5}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="scheduled"
                     name="Con turno"
-                    stroke="#16A34A"
+                    stroke={CHART_COLORS.green}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="invited"
                     name="Invitados"
-                    stroke="#2563EB"
+                    stroke={CHART_COLORS.blue}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
@@ -510,15 +564,15 @@ export function TotemReportDashboardContainer({
                     name="Administrativo"
                     stroke="#64748B"
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                   <Line
                     type="monotone"
                     dataKey="unregistered"
                     name="DNI no encontrado"
-                    stroke="#F97316"
+                    stroke={CHART_COLORS.orange}
                     strokeWidth={2}
-                    dot={{ r: 3 }}
+                    dot={false}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -527,17 +581,19 @@ export function TotemReportDashboardContainer({
         </Card>
       </div>
 
-      <div className="grid gap-7 xl:grid-cols-[1.6fr,1fr]">
-        <Card className="overflow-hidden">
-          <CardHeader>
-            <CardTitle>Detalle diario del Totem</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0">
-            {!reportQuery.data?.daily.length ? (
-              <div className="text-sm text-muted-foreground">
-                Sin tickets del tótem para el rango seleccionado.
-              </div>
-            ) : (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Detalle diario del tótem</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {reportQuery.isLoading ? (
+            <Skeleton className="h-64 w-full" />
+          ) : !visibleDailyItems.length ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Sin tickets del tótem para el período seleccionado.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -548,157 +604,59 @@ export function TotemReportDashboardContainer({
                     <TableHead className="text-right">Administrativo</TableHead>
                     <TableHead className="text-right">DNI no encontrado</TableHead>
                     <TableHead className="text-right">Resueltos</TableHead>
-                    <TableHead className="text-right">Nuevos Totem</TableHead>
+                    <TableHead className="text-right">Altas sistema</TableHead>
+                    <TableHead className="text-right">Trazadas Totem</TableHead>
                     <TableHead className="text-right">Vinculados Totem</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {reportQuery.data.daily.map((item) => (
-                    <TableRow key={item.date}>
-                      <TableCell className="font-medium">
-                        {format(new Date(`${item.date}T00:00:00`), "EEE d MMM", {
-                          locale: es,
-                        })}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.totalTickets)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.scheduled)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.invited)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.administrative)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(item.unregistered)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(dailyResolvedMap.get(item.date) ?? 0)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(
-                          dailyTotemCreatedMap.get(item.date) ?? 0
-                        )}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {numberFormatter.format(
-                          dailyTotemLinkedExistingMap.get(item.date) ?? 0
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="overflow-hidden">
-          <CardHeader>
-            <CardTitle>Resolución de no registrados</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4 pt-0">
-            {reportQuery.data ? (
-              <>
-                <div className="rounded-xl border bg-muted/30 p-4">
-                  <div className="text-sm font-medium">Tasa de resolución</div>
-                  <div className="mt-2 text-3xl font-semibold tracking-tight">
-                    {reportQuery.data.unregistered.resolutionRate.toFixed(2)}%
-                  </div>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Calculada sobre tickets detectados en el rango filtrado.
-                  </p>
-                </div>
-
-                <div className="rounded-xl border border-emerald-100 bg-emerald-50/60 p-4">
-                  <div className="text-sm font-medium">
-                    Pacientes nuevos desde Totem
-                  </div>
-                  <div className="mt-2 text-3xl font-semibold tracking-tight text-emerald-700">
-                    {numberFormatter.format(
-                      reportQuery.data.registrations?.createdPatientsInRange ??
-                        reportQuery.data.unregistered.createdPatientsInRange ??
-                        0
-                    )}
-                  </div>
-                  <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-                    <span>
-                      Invitados:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow?.invited ?? 0
-                      )}
-                    </span>
-                    <span>
-                      DNI no encontrado:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow
-                          ?.unregistered ??
-                          reportQuery.data.unregistered.createdPatientsInRange ??
-                          0
-                      )}
-                    </span>
-                    <span>
-                      Administrativo:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow
-                          ?.administrative ?? 0
-                      )}
-                    </span>
-                    <span>
-                      Con turno:{" "}
-                      {numberFormatter.format(
-                        reportQuery.data.registrations?.createdByFlow?.scheduled ??
-                          0
-                      )}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  {reportQuery.data.unregistered.dailyDetected.map((item) => (
-                    <div
-                      key={item.date}
-                      className="rounded-xl border px-4 py-3"
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <span className="text-sm font-medium">
-                          {format(new Date(`${item.date}T00:00:00`), "EEEE d MMM", {
+                  {visibleDailyItems.map((item) => {
+                    const key = dayKey(item.date);
+                    return (
+                      <TableRow key={item.date}>
+                        <TableCell className="font-medium capitalize">
+                          {format(parseTotemDate(item.date), "EEE d MMM", {
                             locale: es,
                           })}
-                        </span>
-                        <Badge variant="secondary">
-                          {numberFormatter.format(item.total)} detectados
-                        </Badge>
-                      </div>
-                      <div className="mt-2 text-xs text-muted-foreground">
-                        {numberFormatter.format(
-                          dailyResolvedMap.get(item.date) ?? 0
-                        )}{" "}
-                        resueltos con fecha ese día.{" "}
-                        {numberFormatter.format(
-                          dailyCreatedMap.get(item.date) ?? 0
-                        )}{" "}
-                        fueron pacientes nuevos desde DNI no encontrado y{" "}
-                        {numberFormatter.format(
-                          dailyLinkedExistingMap.get(item.date) ?? 0
-                        )}{" "}
-                        fueron vinculaciones a pacientes existentes.
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </>
-            ) : (
-              <div className="text-sm text-muted-foreground">
-                Sin información disponible para el rango seleccionado.
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.totalTickets)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.scheduled)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.invited)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.administrative)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(item.unregistered)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(dailyResolvedMap.get(key) ?? 0)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(dailyRealUsersCreatedMap.get(key) ?? 0)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(dailyTotemCreatedMap.get(key) ?? 0)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatNumber(
+                            dailyTotemLinkedExistingMap.get(key) ?? 0
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/Totem-Analytics/UnregisteredResolutionFunnel.tsx
+++ b/src/components/Totem-Analytics/UnregisteredResolutionFunnel.tsx
@@ -1,0 +1,140 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronRight, UserPlus, Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatNumber } from "@/components/Appointments-Analytics/chartTheme";
+
+interface UnregisteredResolutionFunnelProps {
+  detected: number;
+  resolved: number;
+  createdNew: number;
+  linkedExisting: number;
+  pending: number;
+  resolutionRate: number;
+  isLoading: boolean;
+}
+
+function Step({
+  label,
+  value,
+  share,
+  tone,
+  isLoading,
+}: {
+  label: string;
+  value: number;
+  share?: string;
+  tone: "neutral" | "green" | "amber";
+  isLoading: boolean;
+}) {
+  const valueColor = {
+    neutral: "text-slate-900",
+    green: "text-green-700",
+    amber: "text-amber-700",
+  }[tone];
+
+  return (
+    <div className="min-w-[120px] flex-1 px-2 py-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {isLoading ? (
+        <Skeleton className="mt-1 h-8 w-16" />
+      ) : (
+        <div className="mt-0.5 flex items-baseline gap-2">
+          <span className={cn("text-3xl font-bold leading-none", valueColor)}>
+            {formatNumber(value)}
+          </span>
+          {share && (
+            <span className="text-sm font-medium text-muted-foreground">
+              {share}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function UnregisteredResolutionFunnel({
+  detected,
+  resolved,
+  createdNew,
+  linkedExisting,
+  pending,
+  resolutionRate,
+  isLoading,
+}: UnregisteredResolutionFunnelProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">
+          Resolución de DNI no encontrado
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-col gap-2 rounded-xl border bg-muted/30 p-3 md:flex-row md:items-center md:gap-1">
+          <Step
+            label="Detectados"
+            value={detected}
+            tone="neutral"
+            isLoading={isLoading}
+          />
+          <ChevronRight className="hidden h-5 w-5 shrink-0 self-center text-muted-foreground/40 md:block" />
+          <Step
+            label="Resueltos"
+            value={resolved}
+            share={`${formatNumber(resolutionRate)}%`}
+            tone="green"
+            isLoading={isLoading}
+          />
+          <ChevronRight className="hidden h-5 w-5 shrink-0 self-center text-muted-foreground/40 md:block" />
+          <Step
+            label="Pendientes"
+            value={pending}
+            tone="amber"
+            isLoading={isLoading}
+          />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex items-center gap-3 rounded-xl border border-green-100 bg-green-50/60 px-4 py-3">
+            <div className="rounded-lg bg-green-100 p-2 text-green-700">
+              <UserPlus className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Nuevos pacientes
+              </p>
+              {isLoading ? (
+                <Skeleton className="mt-1 h-6 w-12" />
+              ) : (
+                <p className="text-xl font-bold text-green-700">
+                  {formatNumber(createdNew)}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 rounded-xl border border-blue-100 bg-blue-50/60 px-4 py-3">
+            <div className="rounded-lg bg-blue-100 p-2 text-blue-700">
+              <Link2 className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Vinculados a paciente existente
+              </p>
+              {isLoading ? (
+                <Skeleton className="mt-1 h-6 w-12" />
+              ) : (
+                <p className="text-xl font-bold text-blue-700">
+                  {formatNumber(linkedExisting)}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/Totem-Analytics/useTotemAnalytics.ts
+++ b/src/hooks/Totem-Analytics/useTotemAnalytics.ts
@@ -1,5 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { getTotemAnalyticsReport } from "@/api/Totem-Analytics";
+import {
+  getTotemAnalyticsReport,
+  getTotemPatientRegistrationStats,
+} from "@/api/Totem-Analytics";
 import { TotemAnalyticsFilters } from "@/types/Totem-Analytics/TotemAnalytics";
 
 const serializeFilters = (filters: TotemAnalyticsFilters) => ({
@@ -11,12 +14,28 @@ export const totemAnalyticsKeys = {
   all: ["totemAnalytics"] as const,
   report: (filters: TotemAnalyticsFilters) =>
     [...totemAnalyticsKeys.all, "report", serializeFilters(filters)] as const,
+  patientRegistrations: (filters: TotemAnalyticsFilters) =>
+    [
+      ...totemAnalyticsKeys.all,
+      "patientRegistrations",
+      serializeFilters(filters),
+    ] as const,
 };
 
 export const useTotemAnalyticsReport = (filters: TotemAnalyticsFilters) =>
   useQuery({
     queryKey: totemAnalyticsKeys.report(filters),
     queryFn: () => getTotemAnalyticsReport(filters),
+    enabled: !!filters.dateFrom && !!filters.dateTo,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export const useTotemPatientRegistrationStats = (
+  filters: TotemAnalyticsFilters
+) =>
+  useQuery({
+    queryKey: totemAnalyticsKeys.patientRegistrations(filters),
+    queryFn: () => getTotemPatientRegistrationStats(filters),
     enabled: !!filters.dateFrom && !!filters.dateTo,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/pages/protected/Admin/Appointments-Reports/index.tsx
+++ b/src/pages/protected/Admin/Appointments-Reports/index.tsx
@@ -4,7 +4,6 @@ import { PageHeader } from "@/components/PageHeader";
 import { AppointmentsManagementDashboardContainer } from "@/components/Appointments-Analytics";
 import { TotemReportDashboardContainer } from "@/components/Totem-Analytics";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent } from "@/components/ui/card";
 
 const AppointmentsReportsPage = () => {
   return (
@@ -24,26 +23,22 @@ const AppointmentsReportsPage = () => {
         />
 
         <Tabs defaultValue="appointments" className="space-y-6">
-          <Card className="border-border/70">
-            <CardContent className="pt-6">
-              <TabsList className="h-auto w-full flex-wrap justify-start gap-2 bg-transparent p-0">
-                <TabsTrigger
-                  value="appointments"
-                  className="border border-border/70 px-4 py-2 data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                >
-                  <BarChart3 className="mr-2 h-4 w-4" />
-                  Turnos
-                </TabsTrigger>
-                <TabsTrigger
-                  value="totem"
-                  className="border border-border/70 px-4 py-2 data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
-                >
-                  <Ticket className="mr-2 h-4 w-4" />
-                  Totem
-                </TabsTrigger>
-              </TabsList>
-            </CardContent>
-          </Card>
+          <TabsList className="h-auto w-full flex-wrap justify-start gap-2 border-b bg-transparent p-0">
+            <TabsTrigger
+              value="appointments"
+              className="rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
+            >
+              <BarChart3 className="mr-2 h-4 w-4" />
+              Turnos
+            </TabsTrigger>
+            <TabsTrigger
+              value="totem"
+              className="rounded-none border-b-2 border-transparent px-4 py-2.5 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
+            >
+              <Ticket className="mr-2 h-4 w-4" />
+              Totem
+            </TabsTrigger>
+          </TabsList>
 
           <TabsContent value="appointments" className="mt-0">
             <AppointmentsManagementDashboardContainer showHeader={false} />

--- a/src/types/Totem-Analytics/TotemAnalytics.ts
+++ b/src/types/Totem-Analytics/TotemAnalytics.ts
@@ -62,3 +62,25 @@ export interface TotemAnalyticsReport {
   unregistered: TotemAnalyticsUnregisteredSummary;
   registrations: TotemAnalyticsRegistrationsSummary;
 }
+
+export interface TotemPatientRegistrationStatsSource {
+  primary: string;
+  secondary: string;
+  note: string;
+}
+
+export interface TotemPatientRegistrationDailyStats {
+  date: string;
+  usersCreated: number;
+  patientsCreated: number;
+}
+
+export interface TotemPatientRegistrationStats {
+  dateFrom: string;
+  dateTo: string;
+  timezone: string;
+  source: TotemPatientRegistrationStatsSource;
+  totalUsersCreated: number;
+  totalPatientsCreated: number;
+  daily: TotemPatientRegistrationDailyStats[];
+}


### PR DESCRIPTION
## Resumen

Promoción a `main` del rediseño de los reportes (ya en `develop`):

- **Turnos** (#110, #111): embudo de estados, filtros con chips de valor real, origen en español, gráficos con tema/tooltip compartidos.
- **Totem** (#112): embudo de resolución de DNI no encontrado, lenguaje claro, cruces por fecha correctos, detalle diario con todas las columnas.

### Nota sobre alcance
main había quedado sin la feature de **altas de pacientes** (`patient-registrations`, que lee de Historia Clínica) por un revert previo de un merge develop→main. El reporte del Totem la usa, así que se incluye la **dependencia mínima** (action + hook + tipos) para que compile. Si el endpoint de Historia Clínica no está disponible en producción, esa sección muestra "sin dato" (no rompe el resto).

Trae **solo** los archivos del rediseño + esa dependencia (17 archivos). No arrastra el resto de develop.

## Test plan

- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm run lint`
- [ ] Verificar `/admin/reportes-turnos` (tabs Turnos y Totem) tras el merge
- [ ] Acompañar con el backend a main (appointments PR #51) y redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)