### PR TITLE
feat: estandarizar visibilidad del informe laboral por dato cargado

### DIFF
--- a/src/common/helpers/maps.test.ts
+++ b/src/common/helpers/maps.test.ts
@@ -32,10 +32,10 @@ describe('mapVisual', () => {
       expect(result.agudezaCc).toEqual({ right: '', left: '' });
     });
 
-    it('debe retornar "normal" como default para visión cromática', () => {
+    it('debe retornar undefined para visión cromática sin dato', () => {
       const result = mapVisual([]);
 
-      expect(result.visionCromatica).toBe('normal');
+      expect(result.visionCromatica).toBeUndefined();
     });
 
     it('debe retornar string vacío para notas', () => {
@@ -152,14 +152,14 @@ describe('mapVisual', () => {
       expect(result.visionCromatica).toBe('normal');
     });
 
-    it('debe defaultear a "normal" si el valor es inválido', () => {
+    it('debe retornar undefined si el valor es inválido', () => {
       const dataValues: DataValue[] = [
         createDataValue('Visión Cromática', 'EXAMEN_CLINICO', 'otro_valor'),
       ];
 
       const result = mapVisual(dataValues);
 
-      expect(result.visionCromatica).toBe('normal');
+      expect(result.visionCromatica).toBeUndefined();
     });
 
     it('debe mapear observaciones a notasVision', () => {

--- a/src/common/helpers/maps.ts
+++ b/src/common/helpers/maps.ts
@@ -210,7 +210,7 @@ export function mapVisual(
 ): {
     agudezaSc: { right: string; left: string };
     agudezaCc: { right: string; left: string };
-    visionCromatica: "normal" | "anormal";
+    visionCromatica?: "normal" | "anormal";
     notasVision: string;
 } {
     // Agudeza S/C
@@ -245,7 +245,7 @@ export function mapVisual(
     );
     const cromRaw = (dvCrom?.value as string)?.toLowerCase();
     const visionCromatica =
-        cromRaw === "normal" || cromRaw === "anormal" ? cromRaw : "normal";
+        cromRaw === "normal" || cromRaw === "anormal" ? cromRaw : undefined;
     const notasVision = dvCrom?.observations ?? "";
 
     return {

--- a/src/components/Pre-Occupational/Preview/Collaborator-Information/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Collaborator-Information/index.tsx
@@ -18,38 +18,44 @@ interface CollaboratorInformationHtmlProps {
   compactWorkerOnly?: boolean;
 }
 
-const normalizeDisplayValue = (value: unknown) => {
+const cleanFieldValue = (value: unknown): string => {
   if (value === null || value === undefined) {
-    return "-";
+    return "";
   }
 
   const text = String(value).trim();
   if (!text || text.toLowerCase() === "null" || text.toLowerCase() === "undefined") {
-    return "-";
+    return "";
   }
 
   return text;
 };
 
+// Regla de visibilidad: el campo solo aparece si tiene dato cargado.
 const Field = ({
   label,
   value,
 }: {
   label: string;
-  value: string;
-}) => (
-  <div>
-    <p
-      className="mb-0.5 text-[7px] uppercase tracking-[0.1em]"
-      style={{ color: pdfColors.muted }}
-    >
-      {label}
-    </p>
-    <p className="text-[9px] leading-[1.25]" style={{ color: pdfColors.ink }}>
-      {value || "-"}
-    </p>
-  </div>
-);
+  value: unknown;
+}) => {
+  const text = cleanFieldValue(value);
+  if (!text) return null;
+
+  return (
+    <div>
+      <p
+        className="mb-0.5 text-[7px] uppercase tracking-[0.1em]"
+        style={{ color: pdfColors.muted }}
+      >
+        {label}
+      </p>
+      <p className="text-[9px] leading-[1.25]" style={{ color: pdfColors.ink }}>
+        {text}
+      </p>
+    </div>
+  );
+};
 
 const CardSection = ({
   title,
@@ -96,22 +102,11 @@ const CollaboratorInformationHtml: React.FC<
           <div className="grid grid-cols-4 gap-x-3 gap-y-1.5">
             <Field
               label="Apellido y nombre"
-              value={normalizeDisplayValue(
-                `${collaborator.lastName} ${collaborator.firstName}`
-              )}
+              value={`${collaborator.lastName} ${collaborator.firstName}`}
             />
-            <Field
-              label="DNI"
-              value={normalizeDisplayValue(formatDni(collaborator.userName))}
-            />
-            <Field
-              label="Puesto de trabajo"
-              value={normalizeDisplayValue(collaborator.positionJob)}
-            />
-            <Field
-              label="Fecha de nacimiento"
-              value={normalizeDisplayValue(collaborator.birthDate)}
-            />
+            <Field label="DNI" value={formatDni(collaborator.userName)} />
+            <Field label="Puesto de trabajo" value={collaborator.positionJob} />
+            <Field label="Fecha de nacimiento" value={collaborator.birthDate} />
           </div>
         </CardSection>
       </div>
@@ -123,23 +118,12 @@ const CollaboratorInformationHtml: React.FC<
       <div className="grid grid-cols-2 gap-2.5">
         <CardSection title="Empresa">
           <div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
-            <Field
-              label="Nombre"
-              value={normalizeDisplayValue(companyData.name)}
-            />
-            <Field
-              label="Telefono"
-              value={normalizeDisplayValue(companyData.phone)}
-            />
-            <Field
-              label="CUIT"
-              value={normalizeDisplayValue(formatCuilCuit(companyData.taxId))}
-            />
+            <Field label="Nombre" value={companyData.name} />
+            <Field label="Telefono" value={companyData.phone} />
+            <Field label="CUIT" value={formatCuilCuit(companyData.taxId)} />
             <Field
               label="Domicilio"
-              value={normalizeDisplayValue(
-                formatAddress(companyData.addressData)
-              )}
+              value={formatAddress(companyData.addressData)}
             />
           </div>
         </CardSection>
@@ -148,45 +132,25 @@ const CollaboratorInformationHtml: React.FC<
           <div className="grid grid-cols-[1.25fr_1fr] gap-x-3 gap-y-1.5">
             <Field
               label="Apellido y nombre"
-              value={normalizeDisplayValue(
-                `${collaborator.lastName} ${collaborator.firstName}`
-              )}
+              value={`${collaborator.lastName} ${collaborator.firstName}`}
             />
-            <Field
-              label="DNI"
-              value={normalizeDisplayValue(formatDni(collaborator.userName))}
-            />
-            <Field
-              label="Fecha de nacimiento"
-              value={normalizeDisplayValue(collaborator.birthDate)}
-            />
-            <Field
-              label="Telefono"
-              value={normalizeDisplayValue(collaborator.phone)}
-            />
-            <Field
-              label="Puesto de trabajo"
-              value={normalizeDisplayValue(collaborator.positionJob)}
-            />
+            <Field label="DNI" value={formatDni(collaborator.userName)} />
+            <Field label="Fecha de nacimiento" value={collaborator.birthDate} />
+            <Field label="Telefono" value={collaborator.phone} />
+            <Field label="Puesto de trabajo" value={collaborator.positionJob} />
             <Field
               label="Localidad"
-              value={normalizeDisplayValue(collaborator.addressData?.city.name)}
+              value={collaborator.addressData?.city.name}
             />
           </div>
         </CardSection>
       </div>
 
-      {showAntecedentes ? (
+      {showAntecedentes && antecedentes.length > 0 ? (
         <CardSection title="Antecedentes">
-          {antecedentes.length > 0 ? (
-            <div className="text-[9px] leading-[1.25]">
-              <AntecedentesList dataValues={antecedentes} />
-            </div>
-          ) : (
-            <p className="text-[9px]" style={{ color: pdfColors.muted }}>
-              Sin antecedentes ocupacionales registrados.
-            </p>
-          )}
+          <div className="text-[9px] leading-[1.25]">
+            <AntecedentesList dataValues={antecedentes} />
+          </div>
         </CardSection>
       ) : null}
     </div>

--- a/src/components/Pre-Occupational/Preview/Pdf/Collaborator-Information/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Collaborator-Information/index.tsx
@@ -103,24 +103,30 @@ const styles = StyleSheet.create({
   },
 });
 
-const InfoField = ({ label, value }: { label: string; value: string }) => (
-  <View>
-    <Text style={styles.label}>{label}</Text>
-    <Text style={styles.value}>{value || "-"}</Text>
-  </View>
-);
-
-const normalizeDisplayValue = (value: unknown) => {
+const cleanFieldValue = (value: unknown): string => {
   if (value === null || value === undefined) {
-    return "-";
+    return "";
   }
 
   const text = String(value).trim();
   if (!text || text.toLowerCase() === "null" || text.toLowerCase() === "undefined") {
-    return "-";
+    return "";
   }
 
   return text;
+};
+
+// Regla de visibilidad: el campo solo aparece si tiene dato cargado.
+const InfoField = ({ label, value }: { label: string; value: unknown }) => {
+  const text = cleanFieldValue(value);
+  if (!text) return null;
+
+  return (
+    <View>
+      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.value}>{text}</Text>
+    </View>
+  );
 };
 
 const CollaboratorInformationPdf: React.FC<CollaboratorInformationPdfProps> = ({
@@ -142,27 +148,25 @@ const CollaboratorInformationPdf: React.FC<CollaboratorInformationPdfProps> = ({
               <View style={styles.compactField}>
                 <InfoField
                   label="Apellido y nombre"
-                  value={normalizeDisplayValue(
-                    `${collaborator.lastName}, ${collaborator.firstName}`
-                  )}
+                  value={`${collaborator.lastName}, ${collaborator.firstName}`}
                 />
               </View>
               <View style={styles.compactField}>
                 <InfoField
                   label="DNI"
-                  value={normalizeDisplayValue(formatDni(collaborator.userName))}
+                  value={formatDni(collaborator.userName)}
                 />
               </View>
               <View style={styles.compactField}>
                 <InfoField
                   label="Puesto de trabajo"
-                  value={normalizeDisplayValue(collaborator.positionJob)}
+                  value={collaborator.positionJob}
                 />
               </View>
               <View style={[styles.compactField, { marginRight: 0 }]}>
                 <InfoField
                   label="Fecha de nacimiento"
-                  value={normalizeDisplayValue(collaborator.birthDate)}
+                  value={collaborator.birthDate}
                 />
               </View>
             </View>
@@ -182,31 +186,23 @@ const CollaboratorInformationPdf: React.FC<CollaboratorInformationPdfProps> = ({
           <View style={styles.sectionBody}>
             <View style={styles.row}>
               <View style={styles.field}>
-                <InfoField
-                  label="Nombre"
-                  value={normalizeDisplayValue(companyData.name)}
-                />
+                <InfoField label="Nombre" value={companyData.name} />
               </View>
               <View style={[styles.field, { marginRight: 0 }]}>
-                <InfoField
-                  label="Telefono"
-                  value={normalizeDisplayValue(companyData.phone)}
-                />
+                <InfoField label="Telefono" value={companyData.phone} />
               </View>
             </View>
             <View style={[styles.row, styles.rowLast]}>
               <View style={styles.field}>
                 <InfoField
                   label="CUIT"
-                  value={normalizeDisplayValue(formatCuilCuit(companyData.taxId))}
+                  value={formatCuilCuit(companyData.taxId)}
                 />
               </View>
               <View style={[styles.field, { marginRight: 0 }]}>
                 <InfoField
                   label="Domicilio"
-                  value={normalizeDisplayValue(
-                    formatAddress(companyData.addressData)
-                  )}
+                  value={formatAddress(companyData.addressData)}
                 />
               </View>
             </View>
@@ -222,15 +218,13 @@ const CollaboratorInformationPdf: React.FC<CollaboratorInformationPdfProps> = ({
               <View style={styles.field}>
                 <InfoField
                   label="Apellido y nombre"
-                  value={normalizeDisplayValue(
-                    `${collaborator.lastName}, ${collaborator.firstName}`
-                  )}
+                  value={`${collaborator.lastName}, ${collaborator.firstName}`}
                 />
               </View>
               <View style={[styles.field, { marginRight: 0 }]}>
                 <InfoField
                   label="DNI"
-                  value={normalizeDisplayValue(formatDni(collaborator.userName))}
+                  value={formatDni(collaborator.userName)}
                 />
               </View>
             </View>
@@ -238,29 +232,24 @@ const CollaboratorInformationPdf: React.FC<CollaboratorInformationPdfProps> = ({
               <View style={styles.field}>
                 <InfoField
                   label="Fecha de nacimiento"
-                  value={normalizeDisplayValue(collaborator.birthDate)}
+                  value={collaborator.birthDate}
                 />
               </View>
               <View style={[styles.field, { marginRight: 0 }]}>
-                <InfoField
-                  label="Telefono"
-                  value={normalizeDisplayValue(collaborator.phone)}
-                />
+                <InfoField label="Telefono" value={collaborator.phone} />
               </View>
             </View>
             <View style={[styles.row, styles.rowLast]}>
               <View style={styles.field}>
                 <InfoField
                   label="Puesto de trabajo"
-                  value={normalizeDisplayValue(collaborator.positionJob)}
+                  value={collaborator.positionJob}
                 />
               </View>
               <View style={[styles.field, { marginRight: 0 }]}>
                 <InfoField
                   label="Localidad"
-                  value={normalizeDisplayValue(
-                    collaborator.addressData?.city.name
-                  )}
+                  value={collaborator.addressData?.city.name}
                 />
               </View>
             </View>
@@ -268,24 +257,18 @@ const CollaboratorInformationPdf: React.FC<CollaboratorInformationPdfProps> = ({
         </View>
       </View>
 
-      {showAntecedentes ? (
+      {showAntecedentes && antecedentes && antecedentes.length > 0 ? (
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
             <Text style={styles.sectionTitle}>Antecedentes</Text>
           </View>
           <View style={styles.sectionBody}>
             <View style={styles.antecedentesBlock}>
-              {antecedentes && antecedentes.length > 0 ? (
-                antecedentes.map((antecedente, index) => (
-                  <Text key={antecedente.id} style={styles.antecedentesItem}>
-                    {index + 1}. {String(antecedente.value)}
-                  </Text>
-                ))
-              ) : (
-                <Text style={styles.emptyText}>
-                  Sin antecedentes ocupacionales registrados.
+              {antecedentes.map((antecedente, index) => (
+                <Text key={antecedente.id} style={styles.antecedentesItem}>
+                  {index + 1}. {String(antecedente.value)}
                 </Text>
-              )}
+              ))}
             </View>
           </View>
         </View>

--- a/src/components/Pre-Occupational/Preview/Pdf/Document/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Document/index.tsx
@@ -25,6 +25,7 @@ import {
   resolveReportVisibility,
 } from "@/common/helpers/report-visibility";
 import { LaborReportBrandingConfig } from "@/types/Labor-Report-Branding-Config/LaborReportBrandingConfig";
+import { hasClinicalPageData } from "../../page-visibility";
 
 interface Props {
   collaborator: Collaborator;
@@ -87,7 +88,17 @@ const PDFDocument = ({
     hasSectionData(medicalEvaluation.gastrointestinal) ||
     hasSectionData(medicalEvaluation.osteoarticular) ||
     hasVisibleGenitourinario;
-  const thirdPageNumber = 3;
+  const hasSecondPage = hasClinicalPageData({
+    aspectoGeneral: infoGeneral.aspectoGeneral,
+    peso: clinicalEvaluation.peso,
+    talla: clinicalEvaluation.talla,
+    imc: clinicalEvaluation.imc,
+    agudezaSc: medicalEvaluation.agudezaSc,
+    agudezaCc: medicalEvaluation.agudezaCc,
+    visionCromatica: medicalEvaluation.visionCromatica,
+    notasVision: medicalEvaluation.notasVision,
+  });
+  const thirdPageNumber = 2 + (hasSecondPage ? 1 : 0);
   const fourthPageNumber = thirdPageNumber + (hasThirdPage ? 1 : 0);
   const fifthPageNumber = fourthPageNumber + (hasFourthPage ? 1 : 0);
   const firstStudyPageNumber = fifthPageNumber + (hasFifthPage ? 1 : 0);
@@ -104,19 +115,21 @@ const PDFDocument = ({
         brandingConfig={brandingConfig}
         pageNumber={1}
       />
-      <SecondPagePdfDocument
-        collaborator={collaborator}
-        talla={clinicalEvaluation.talla}
-        peso={clinicalEvaluation.peso}
-        imc={clinicalEvaluation.imc}
-        medicalEvaluationType={medicalEvaluationType}
-        antecedentes={antecedentes}
-        doctorData={doctorData}
-        data={medicalEvaluation}
-        aspectoGeneral={infoGeneral.aspectoGeneral}
-        brandingConfig={brandingConfig}
-        pageNumber={2}
-      />
+      {hasSecondPage ? (
+        <SecondPagePdfDocument
+          collaborator={collaborator}
+          talla={clinicalEvaluation.talla}
+          peso={clinicalEvaluation.peso}
+          imc={clinicalEvaluation.imc}
+          medicalEvaluationType={medicalEvaluationType}
+          antecedentes={antecedentes}
+          doctorData={doctorData}
+          data={medicalEvaluation}
+          aspectoGeneral={infoGeneral.aspectoGeneral}
+          brandingConfig={brandingConfig}
+          pageNumber={2}
+        />
+      ) : null}
       <ThirdPagePdfDocument
         data={medicalEvaluation}
         doctorData={doctorData}

--- a/src/components/Pre-Occupational/Preview/Pdf/First-Page/Exams-Results/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/First-Page/Exams-Results/index.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { View, Text, StyleSheet } from "@react-pdf/renderer";
 import { ExamResults } from "@/common/helpers/examsResults.maps";
 import { pdfColors } from "../../shared";
-import {
-  emptyExamResultsMessage,
-  getVisibleExamResultRows,
-} from "../../../exam-results-visibility";
+import { getVisibleExamResultRows } from "../../../exam-results-visibility";
 
 interface ExamResultsPdfProps {
   examResults: ExamResults;
@@ -62,15 +59,13 @@ const styles = StyleSheet.create({
     lineHeight: 1.22,
     flexShrink: 1,
   },
-  emptyMessage: {
-    fontSize: 8,
-    color: pdfColors.muted,
-    lineHeight: 1.22,
-  },
 });
 
 const ExamResultsPdf: React.FC<ExamResultsPdfProps> = ({ examResults }) => {
   const rows = getVisibleExamResultRows(examResults);
+
+  // Regla de visibilidad: si no hay resultados cargados, la seccion no aparece.
+  if (rows.length === 0) return null;
 
   return (
     <View style={styles.container}>
@@ -78,9 +73,7 @@ const ExamResultsPdf: React.FC<ExamResultsPdfProps> = ({ examResults }) => {
         <Text style={styles.headerText}>Resultados del examen</Text>
       </View>
       <View style={styles.body}>
-        {rows.length === 0 ? (
-          <Text style={styles.emptyMessage}>{emptyExamResultsMessage}</Text>
-        ) : rows.map((row, index) => (
+        {rows.map((row, index) => (
           <View
             key={row.valueKey}
             style={

--- a/src/components/Pre-Occupational/Preview/Pdf/Second-Page/Clinical-Evaluation/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Second-Page/Clinical-Evaluation/index.tsx
@@ -88,41 +88,58 @@ const AspectoGeneralValue = ({ value }: { value?: string }) => {
   );
 };
 
-const InfoField = ({ label, value }: { label: string; value: string }) => (
-  <View style={styles.infoField}>
-    <Text style={styles.infoLabel}>{label}</Text>
-    <Text style={styles.infoValue}>{value || "—"}</Text>
-  </View>
-);
+const InfoField = ({ label, value }: { label: string; value: string }) => {
+  if (!value?.trim()) return null;
+  return (
+    <View style={styles.infoField}>
+      <Text style={styles.infoLabel}>{label}</Text>
+      <Text style={styles.infoValue}>{value}</Text>
+    </View>
+  );
+};
 
 const ClinicalEvaluationPdf: React.FC<ClinicalEvaluationPdfProps> = ({
   aspectoGeneral,
   peso,
   talla,
   imc,
-}) => (
-  <View style={styles.container}>
-    <View style={styles.headerWrap}>
-      <Text style={styles.header}>Examen clinico</Text>
-    </View>
-    <View style={styles.body}>
-      {aspectoGeneral?.trim() && (
-        <View style={styles.sectionRow}>
-          <Text style={styles.sectionLabel}>Aspecto general</Text>
-          <AspectoGeneralValue value={aspectoGeneral} />
-        </View>
-      )}
+}) => {
+  const hasAspecto = Boolean(aspectoGeneral?.trim());
+  const mediciones = [
+    { label: "Peso (kg)", value: peso },
+    { label: "Talla (cm)", value: talla },
+    { label: "IMC", value: imc },
+  ].filter((m) => m.value?.trim());
 
-      <View style={styles.sectionRow}>
-        <Text style={styles.sectionLabel}>Mediciones</Text>
-        <View style={styles.valueRow}>
-          <InfoField label="Peso (kg)" value={peso} />
-          <InfoField label="Talla (cm)" value={talla} />
-          <InfoField label="IMC" value={imc} />
-        </View>
+  // Regla de visibilidad: sin aspecto ni mediciones cargadas, la seccion no aparece.
+  if (!hasAspecto && mediciones.length === 0) return null;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerWrap}>
+        <Text style={styles.header}>Examen clinico</Text>
+      </View>
+      <View style={styles.body}>
+        {hasAspecto && (
+          <View style={styles.sectionRow}>
+            <Text style={styles.sectionLabel}>Aspecto general</Text>
+            <AspectoGeneralValue value={aspectoGeneral} />
+          </View>
+        )}
+
+        {mediciones.length > 0 && (
+          <View style={styles.sectionRow}>
+            <Text style={styles.sectionLabel}>Mediciones</Text>
+            <View style={styles.valueRow}>
+              {mediciones.map((m) => (
+                <InfoField key={m.label} label={m.label} value={m.value} />
+              ))}
+            </View>
+          </View>
+        )}
       </View>
     </View>
-  </View>
-);
+  );
+};
 
 export default ClinicalEvaluationPdf;

--- a/src/components/Pre-Occupational/Preview/Pdf/Second-Page/Visual/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Second-Page/Visual/index.tsx
@@ -5,7 +5,7 @@ import { pdfColors } from "../../shared";
 interface VisualAcuityPdfProps {
   withoutCorrection: { right: string; left: string };
   withCorrection?: { right?: string; left?: string };
-  chromaticVision: "normal" | "anormal";
+  chromaticVision?: "normal" | "anormal";
   notes?: string;
 }
 
@@ -106,12 +106,23 @@ const styles = StyleSheet.create({
 
 export default function VisualAcuityPdf({
   withoutCorrection,
-  withCorrection = { right: "—", left: "—" },
+  withCorrection = {},
   chromaticVision,
   notes = "",
 }: VisualAcuityPdfProps) {
   const chromaColor = chromaticVision === "normal" ? "#006400" : "#8B0000";
   const chromaText = chromaticVision === "normal" ? "Normal" : "Anormal";
+
+  // Regla de visibilidad: la seccion aparece solo si hay agudeza, vision cromatica o notas.
+  const hasAcuity = Boolean(
+    withoutCorrection.right?.trim() ||
+      withoutCorrection.left?.trim() ||
+      withCorrection.right?.trim() ||
+      withCorrection.left?.trim()
+  );
+  const hasChroma = chromaticVision === "normal" || chromaticVision === "anormal";
+  const hasNotes = notes.trim() !== "";
+  if (!hasAcuity && !hasChroma && !hasNotes) return null;
 
   return (
     <View style={styles.container}>
@@ -119,6 +130,7 @@ export default function VisualAcuityPdf({
         <Text style={styles.title}>Agudeza visual</Text>
       </View>
       <View style={styles.body}>
+        {hasAcuity && (
         <View style={styles.table}>
           <View style={styles.row}>
             <View style={[styles.cell, styles.firstCol]}>
@@ -136,10 +148,10 @@ export default function VisualAcuityPdf({
               <Text style={styles.bodyCell}>Ojo derecho</Text>
             </View>
             <View style={styles.cell}>
-              <Text style={styles.bodyCell}>{withoutCorrection.right}</Text>
+              <Text style={styles.bodyCell}>{withoutCorrection.right || "—"}</Text>
             </View>
             <View style={[styles.cell, { borderRightWidth: 0 }]}>
-              <Text style={styles.bodyCell}>{withCorrection.right}</Text>
+              <Text style={styles.bodyCell}>{withCorrection.right || "—"}</Text>
             </View>
           </View>
           <View style={styles.row}>
@@ -147,7 +159,7 @@ export default function VisualAcuityPdf({
               <Text style={styles.bodyCell}>Ojo izquierdo</Text>
             </View>
             <View style={[styles.cell, { borderBottomWidth: 0 }]}>
-              <Text style={styles.bodyCell}>{withoutCorrection.left}</Text>
+              <Text style={styles.bodyCell}>{withoutCorrection.left || "—"}</Text>
             </View>
             <View
               style={[
@@ -155,17 +167,20 @@ export default function VisualAcuityPdf({
                 { borderRightWidth: 0, borderBottomWidth: 0 },
               ]}
             >
-              <Text style={styles.bodyCell}>{withCorrection.left}</Text>
+              <Text style={styles.bodyCell}>{withCorrection.left || "—"}</Text>
             </View>
           </View>
         </View>
+        )}
 
+        {hasChroma && (
         <View style={styles.chromaRow}>
           <Text style={styles.chromaLabel}>Vision cromatica</Text>
           <Text style={[styles.chromaValue, { color: chromaColor }]}>
             {chromaText}
           </Text>
         </View>
+        )}
 
         {notes.trim() !== "" && (
           <View style={styles.notesContainer}>

--- a/src/components/Pre-Occupational/Preview/Pdf/Second-Page/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Second-Page/index.tsx
@@ -101,7 +101,7 @@ const SecondPagePdfDocument = ({
         <View style={styles.sectionWrapper}>
           <VisualAcuityPdf
             withCorrection={data.agudezaCc}
-            chromaticVision={data.visionCromatica!}
+            chromaticVision={data.visionCromatica}
             withoutCorrection={data.agudezaSc}
             notes={data.notasVision}
           />

--- a/src/components/Pre-Occupational/Preview/View/First-Page/Exams-Results/index.tsx
+++ b/src/components/Pre-Occupational/Preview/View/First-Page/Exams-Results/index.tsx
@@ -1,10 +1,7 @@
 import { ExamResults } from "@/common/helpers/examsResults.maps";
 import React from "react";
 import { pdfColors } from "../../../Pdf/shared";
-import {
-  emptyExamResultsMessage,
-  getVisibleExamResultRows,
-} from "../../../exam-results-visibility";
+import { getVisibleExamResultRows } from "../../../exam-results-visibility";
 
 
 interface ExamResultsHtmlProps {
@@ -13,6 +10,9 @@ interface ExamResultsHtmlProps {
 
 const ExamResultsHtml: React.FC<ExamResultsHtmlProps> = ({ examResults }) => {
   const rows = getVisibleExamResultRows(examResults);
+
+  // Regla de visibilidad: si no hay resultados cargados, la seccion no aparece.
+  if (rows.length === 0) return null;
 
   return (
     <div
@@ -34,14 +34,7 @@ const ExamResultsHtml: React.FC<ExamResultsHtmlProps> = ({ examResults }) => {
         </p>
       </div>
       <div className="space-y-1 px-[10px] py-[8px]">
-        {rows.length === 0 ? (
-          <p
-            className="text-[8px] leading-[1.22]"
-            style={{ color: pdfColors.muted }}
-          >
-            {emptyExamResultsMessage}
-          </p>
-        ) : rows.map((row, index) => (
+        {rows.map((row, index) => (
           <div
             key={row.valueKey}
             className={`grid grid-cols-[124px_1fr] gap-[8px] pb-[4px] ${
@@ -67,6 +60,7 @@ const ExamResultsHtml: React.FC<ExamResultsHtmlProps> = ({ examResults }) => {
           </div>
         ))}
       </div>
+
     </div>
   );
 };

--- a/src/components/Pre-Occupational/Preview/View/Second-Page/Clinical-Evaluation/index.tsx
+++ b/src/components/Pre-Occupational/Preview/View/Second-Page/Clinical-Evaluation/index.tsx
@@ -17,6 +17,16 @@ const ClinicalEvaluationHtml: React.FC<ClinicalEvaluationHtmlProps> = ({
   imc,
   aspectoGeneral,
 }) => {
+  const hasAspecto = Boolean(aspectoGeneral?.trim());
+  const mediciones = [
+    { label: "Peso (kg)", value: peso },
+    { label: "Talla (cm)", value: talla },
+    { label: "IMC", value: imc },
+  ].filter((m) => m.value?.trim());
+
+  // Regla de visibilidad: sin aspecto ni mediciones cargadas, la seccion no aparece.
+  if (!hasAspecto && mediciones.length === 0) return null;
+
   return (
     <div
       className="mb-2.5 overflow-hidden rounded-[8px] border"
@@ -52,37 +62,35 @@ const ClinicalEvaluationHtml: React.FC<ClinicalEvaluationHtmlProps> = ({
           </div>
         )}
 
-        <div className="space-y-1">
-          <p
-            className="text-[8px] uppercase tracking-[0.08em]"
-            style={{ color: pdfColors.muted }}
-          >
-            Mediciones
-          </p>
-          <div className="grid grid-cols-3 gap-[10px]">
-            {[
-              { label: "Peso (kg)", value: peso },
-              { label: "Talla (cm)", value: talla },
-              { label: "IMC", value: imc },
-            ].map((item) => (
-              <div
-                key={item.label}
-                className="rounded-[6px] border bg-white px-[10px] py-[8px]"
-                style={{ borderColor: pdfColors.line }}
-              >
-                <p
-                  className="mb-1 text-[8px] uppercase tracking-[0.08em]"
-                  style={{ color: pdfColors.muted }}
+        {mediciones.length > 0 && (
+          <div className="space-y-1">
+            <p
+              className="text-[8px] uppercase tracking-[0.08em]"
+              style={{ color: pdfColors.muted }}
+            >
+              Mediciones
+            </p>
+            <div className="grid grid-cols-3 gap-[10px]">
+              {mediciones.map((item) => (
+                <div
+                  key={item.label}
+                  className="rounded-[6px] border bg-white px-[10px] py-[8px]"
+                  style={{ borderColor: pdfColors.line }}
                 >
-                  {item.label}
-                </p>
-                <p className="text-[10px] font-semibold text-slate-900">
-                  {item.value || "—"}
-                </p>
-              </div>
-            ))}
+                  <p
+                    className="mb-1 text-[8px] uppercase tracking-[0.08em]"
+                    style={{ color: pdfColors.muted }}
+                  >
+                    {item.label}
+                  </p>
+                  <p className="text-[10px] font-semibold text-slate-900">
+                    {item.value}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Pre-Occupational/Preview/View/Second-Page/Visual/index.tsx
+++ b/src/components/Pre-Occupational/Preview/View/Second-Page/Visual/index.tsx
@@ -11,16 +11,27 @@ import { pdfColors } from "../../../Pdf/shared";
 interface VisualAcuityHtmlProps {
   withoutCorrection: { right: string; left: string };
   withCorrection?: { right?: string; left?: string };
-  chromaticVision: "normal" | "anormal";
+  chromaticVision?: "normal" | "anormal";
   notes?: string;
 }
 
 export default function VisualAcuityHtml({
   withoutCorrection,
-  withCorrection = { right: "-", left: "-" },
+  withCorrection = {},
   chromaticVision,
   notes = "",
 }: VisualAcuityHtmlProps) {
+  // Regla de visibilidad: la seccion aparece solo si hay agudeza, vision cromatica o notas.
+  const hasAcuity = Boolean(
+    withoutCorrection.right?.trim() ||
+      withoutCorrection.left?.trim() ||
+      withCorrection.right?.trim() ||
+      withCorrection.left?.trim()
+  );
+  const hasChroma = chromaticVision === "normal" || chromaticVision === "anormal";
+  const hasNotes = Boolean(notes && notes.trim() !== "");
+  if (!hasAcuity && !hasChroma && !hasNotes) return null;
+
   return (
     <div
       className="mb-2.5 overflow-hidden rounded-[8px] border"
@@ -42,6 +53,7 @@ export default function VisualAcuityHtml({
       </div>
 
       <div className="space-y-2.5 px-3 py-[9px]">
+        {hasAcuity && (
         <div
           className="overflow-hidden rounded-[6px] border"
           style={{ borderColor: pdfColors.line }}
@@ -69,25 +81,27 @@ export default function VisualAcuityHtml({
               <TableRow>
                 <TableCell>Ojo derecho</TableCell>
                 <TableCell className="text-center">
-                  {withoutCorrection.right}
+                  {withoutCorrection.right || "—"}
                 </TableCell>
                 <TableCell className="text-center">
-                  {withCorrection.right}
+                  {withCorrection.right || "—"}
                 </TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Ojo izquierdo</TableCell>
                 <TableCell className="text-center">
-                  {withoutCorrection.left}
+                  {withoutCorrection.left || "—"}
                 </TableCell>
                 <TableCell className="text-center">
-                  {withCorrection.left}
+                  {withCorrection.left || "—"}
                 </TableCell>
               </TableRow>
             </TableBody>
           </Table>
         </div>
+        )}
 
+        {hasChroma && (
         <div className="flex items-center gap-2">
           <p
             className="text-[8px] uppercase tracking-[0.08em]"
@@ -105,6 +119,7 @@ export default function VisualAcuityHtml({
             {chromaticVision === "normal" ? "Normal" : "Anormal"}
           </span>
         </div>
+        )}
 
         {notes && (
           <div className="space-y-1">

--- a/src/components/Pre-Occupational/Preview/View/Second-Page/index.tsx
+++ b/src/components/Pre-Occupational/Preview/View/Second-Page/index.tsx
@@ -29,7 +29,7 @@ interface Props {
   antecedentes: DataValue[];
   visualWithout: { right: string; left: string };
   visualWith?: { right?: string; left?: string };
-  visualChromatic: "normal" | "anormal";
+  visualChromatic?: "normal" | "anormal";
   visualNotes?: string;
   doctorData: DoctorSignatures;
   brandingConfig?: LaborReportBrandingConfig;

--- a/src/components/Pre-Occupational/Preview/View/index.tsx
+++ b/src/components/Pre-Occupational/Preview/View/index.tsx
@@ -27,6 +27,7 @@ import {
   resolveReportVisibility,
 } from "@/common/helpers/report-visibility";
 import { LaborReportBrandingConfig } from "@/types/Labor-Report-Branding-Config/LaborReportBrandingConfig";
+import { hasClinicalPageData } from "../page-visibility";
 
 interface Props {
   collaborator: Collaborator;
@@ -90,7 +91,17 @@ const View: React.FC<Props> = ({
     hasSectionData(medicalEvaluation.gastrointestinal) ||
     hasSectionData(medicalEvaluation.osteoarticular) ||
     hasVisibleGenitourinario;
-  const thirdPageNumber = 3;
+  const hasSecondPage = hasClinicalPageData({
+    aspectoGeneral: infoGeneral.aspectoGeneral,
+    peso: clinicalEvaluation.peso,
+    talla: clinicalEvaluation.talla,
+    imc: clinicalEvaluation.imc,
+    agudezaSc: medicalEvaluation.agudezaSc,
+    agudezaCc: medicalEvaluation.agudezaCc,
+    visionCromatica: medicalEvaluation.visionCromatica,
+    notasVision: medicalEvaluation.notasVision,
+  });
+  const thirdPageNumber = 2 + (hasSecondPage ? 1 : 0);
   const fourthPageNumber = thirdPageNumber + (hasThirdPage ? 1 : 0);
   const fifthPageNumber = fourthPageNumber + (hasFourthPage ? 1 : 0);
   const firstStudyPageNumber = fifthPageNumber + (hasFifthPage ? 1 : 0);
@@ -107,29 +118,31 @@ const View: React.FC<Props> = ({
         brandingConfig={brandingConfig}
         pageNumber={1}
       />
-      <SecondPageHTML
-        collaborator={collaborator}
-        talla={clinicalEvaluation.talla}
-        peso={clinicalEvaluation.peso}
-        imc={clinicalEvaluation.imc}
-        medicalEvaluationType={medicalEvaluationType}
-        antecedentes={antecedentes}
-        examenFisico={physicalEvaluation}
-        aspectoGeneral={infoGeneral.aspectoGeneral}
-        tiempoLibre={infoGeneral.tiempoLibre}
-        frecuenciaCardiaca={clinicalEvaluation.frecuenciaCardiaca}
-        frecuenciaRespiratoria={clinicalEvaluation.frecuenciaRespiratoria}
-        perimetroAbdominal={clinicalEvaluation.perimetroAbdominal}
-        presionDiastolica={clinicalEvaluation.presionDiastolica}
-        presionSistolica={clinicalEvaluation.presionSistolica}
-        visualChromatic={medicalEvaluation.visionCromatica!}
-        visualWithout={medicalEvaluation.agudezaSc}
-        visualWith={medicalEvaluation.agudezaCc}
-        visualNotes={medicalEvaluation.notasVision}
-        doctorData={doctorData}
-        brandingConfig={brandingConfig}
-        pageNumber={2}
-      />
+      {hasSecondPage && (
+        <SecondPageHTML
+          collaborator={collaborator}
+          talla={clinicalEvaluation.talla}
+          peso={clinicalEvaluation.peso}
+          imc={clinicalEvaluation.imc}
+          medicalEvaluationType={medicalEvaluationType}
+          antecedentes={antecedentes}
+          examenFisico={physicalEvaluation}
+          aspectoGeneral={infoGeneral.aspectoGeneral}
+          tiempoLibre={infoGeneral.tiempoLibre}
+          frecuenciaCardiaca={clinicalEvaluation.frecuenciaCardiaca}
+          frecuenciaRespiratoria={clinicalEvaluation.frecuenciaRespiratoria}
+          perimetroAbdominal={clinicalEvaluation.perimetroAbdominal}
+          presionDiastolica={clinicalEvaluation.presionDiastolica}
+          presionSistolica={clinicalEvaluation.presionSistolica}
+          visualChromatic={medicalEvaluation.visionCromatica}
+          visualWithout={medicalEvaluation.agudezaSc}
+          visualWith={medicalEvaluation.agudezaCc}
+          visualNotes={medicalEvaluation.notasVision}
+          doctorData={doctorData}
+          brandingConfig={brandingConfig}
+          pageNumber={2}
+        />
+      )}
       <ThirdPageHTML
         pielData={medicalEvaluation.piel!}
         cabezaCuello={medicalEvaluation.cabezaCuello!}

--- a/src/components/Pre-Occupational/Preview/__tests__/page-visibility.test.ts
+++ b/src/components/Pre-Occupational/Preview/__tests__/page-visibility.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { hasClinicalPageData } from "../page-visibility";
+
+describe("hasClinicalPageData", () => {
+  it("es false cuando no hay ningun dato clinico cargado", () => {
+    expect(hasClinicalPageData({})).toBe(false);
+    expect(
+      hasClinicalPageData({
+        aspectoGeneral: "   ",
+        peso: "",
+        talla: "",
+        imc: "",
+        agudezaSc: { right: "", left: "" },
+        agudezaCc: { right: "", left: "" },
+        visionCromatica: undefined,
+        notasVision: "",
+      })
+    ).toBe(false);
+  });
+
+  it("es true si hay aspecto general", () => {
+    expect(hasClinicalPageData({ aspectoGeneral: "Bueno" })).toBe(true);
+  });
+
+  it("es true si hay alguna medicion", () => {
+    expect(hasClinicalPageData({ peso: "80" })).toBe(true);
+    expect(hasClinicalPageData({ talla: "175" })).toBe(true);
+    expect(hasClinicalPageData({ imc: "26" })).toBe(true);
+  });
+
+  it("es true si hay agudeza visual", () => {
+    expect(
+      hasClinicalPageData({ agudezaSc: { right: "10/10", left: "" } })
+    ).toBe(true);
+    expect(
+      hasClinicalPageData({ agudezaCc: { right: "", left: "9/10" } })
+    ).toBe(true);
+  });
+
+  it("es true si hay vision cromatica cargada", () => {
+    expect(hasClinicalPageData({ visionCromatica: "normal" })).toBe(true);
+    expect(hasClinicalPageData({ visionCromatica: "anormal" })).toBe(true);
+  });
+
+  it("es true si hay observaciones de vision", () => {
+    expect(hasClinicalPageData({ notasVision: "usa lentes" })).toBe(true);
+  });
+});

--- a/src/components/Pre-Occupational/Preview/__tests__/report-content-visibility.test.tsx
+++ b/src/components/Pre-Occupational/Preview/__tests__/report-content-visibility.test.tsx
@@ -115,23 +115,25 @@ describe("labor report content visibility", () => {
     expect(screen.queryByText("Sin dato registrado")).not.toBeInTheDocument();
   });
 
-  it("uses the same empty result message in HTML preview and PDF", () => {
+  it("oculta la seccion de resultados cuando no hay datos (HTML y PDF)", () => {
     const emptyResults = {} as ExamResults;
 
-    const { unmount } = render(<ExamResultsHtml examResults={emptyResults} />);
+    const { container, unmount } = render(
+      <ExamResultsHtml examResults={emptyResults} />
+    );
 
+    // Regla de visibilidad: sin resultados, la seccion no se renderiza.
+    expect(container).toBeEmptyDOMElement();
     expect(
-      screen.getByText("No se registraron resultados de estudios")
-    ).toBeInTheDocument();
+      screen.queryByText("Resultados del examen")
+    ).not.toBeInTheDocument();
 
     unmount();
 
-    render(<ExamResultsPdf examResults={emptyResults} />);
-
-    expect(
-      screen.getByText("No se registraron resultados de estudios")
-    ).toBeInTheDocument();
-    expect(screen.queryByText("Sin dato registrado")).not.toBeInTheDocument();
+    const { container: pdfContainer } = render(
+      <ExamResultsPdf examResults={emptyResults} />
+    );
+    expect(pdfContainer).toBeEmptyDOMElement();
   });
 
   it("ignores old gineco-obstetric force_hide overrides in HTML preview", () => {

--- a/src/components/Pre-Occupational/Preview/exam-results-visibility.ts
+++ b/src/components/Pre-Occupational/Preview/exam-results-visibility.ts
@@ -10,9 +10,6 @@ export const examResultRows = [
   { label: "Electroencefalograma", valueKey: "electroencefalograma" },
 ] as const;
 
-export const emptyExamResultsMessage =
-  "No se registraron resultados de estudios";
-
 export const normalizeResultValue = (value?: string): string | null => {
   const text = String(value ?? "").trim();
 

--- a/src/components/Pre-Occupational/Preview/page-visibility.ts
+++ b/src/components/Pre-Occupational/Preview/page-visibility.ts
@@ -1,0 +1,39 @@
+// Helpers de visibilidad de paginas del informe preocupacional.
+// Regla uniforme: una pagina/seccion aparece solo si tiene datos cargados.
+
+interface ClinicalPageInput {
+  aspectoGeneral?: string;
+  peso?: string;
+  talla?: string;
+  imc?: string;
+  agudezaSc?: { right?: string; left?: string };
+  agudezaCc?: { right?: string; left?: string };
+  visionCromatica?: "normal" | "anormal";
+  notasVision?: string;
+}
+
+const hasText = (value?: string): boolean => Boolean(value && value.trim());
+
+/**
+ * Determina si la pagina de Examen Clinico (pagina 2) tiene algun dato cargado:
+ * aspecto general, mediciones (peso/talla/imc), agudeza visual, vision cromatica
+ * u observaciones de vision. Si no hay nada, la pagina no debe imprimirse.
+ */
+export function hasClinicalPageData(input: ClinicalPageInput): boolean {
+  const hasClinical =
+    hasText(input.aspectoGeneral) ||
+    hasText(input.peso) ||
+    hasText(input.talla) ||
+    hasText(input.imc);
+
+  const hasVisual =
+    hasText(input.agudezaSc?.right) ||
+    hasText(input.agudezaSc?.left) ||
+    hasText(input.agudezaCc?.right) ||
+    hasText(input.agudezaCc?.left) ||
+    input.visionCromatica === "normal" ||
+    input.visionCromatica === "anormal" ||
+    hasText(input.notasVision);
+
+  return hasClinical || hasVisual;
+}


### PR DESCRIPTION
## Resumen

Estandariza la lógica de visibilidad del informe preocupacional (View en pantalla + PDF) bajo una regla uniforme: **una sección o campo aparece solo si tiene dato cargado; si está vacío, no se muestra.**

Antes, varias secciones de la portada y del examen clínico se mostraban siempre con rellenos ("-", "—", "Sin ... registrado") aunque estuvieran vacías, mientras que el examen físico por aparatos ya se ocultaba. Esto unifica el criterio.

## Cambios

- **Datos de empresa/trabajador**: se ocultan los campos vacíos (sin `"-"`), manteniendo el bloque de identificación.
- **Antecedentes ocupacionales**: la card se oculta si no hay items.
- **Resultados de estudios**: la sección se oculta si no hay filas.
- **Mediciones (peso/talla/imc) y agudeza visual**: se ocultan cuando están vacías.
- **Examen clínico (página 2)**: se oculta la página completa si no hay ningún dato clínico; numeración de páginas ajustada (helper compartido `page-visibility.ts` para evitar divergencia View/PDF).
- **Fix**: `mapVisual` ya no defaultea visión cromática a `"normal"` cuando no hay dato (`visionCromatica` pasa a opcional). Evitaba afirmar un resultado no evaluado.
- **Excepciones (por requisito del informe)**: la conclusión/dictamen y la leyenda legal se siguen mostrando siempre.

## Decisiones de producto (acordadas)

- Conclusión vacía → se sigue mostrando siempre.
- Identificación → ocultar solo campos vacíos, manteniendo el bloque.
- Página 2 vacía → ocultar la hoja completa (consistente con páginas 3/4/5).

## Test plan

- `npm run type-check` ✅
- `npm run build` ✅
- `npm run lint` (archivos tocados) ✅
- `npm run test:run` → 456 tests ✅ (incluye tests nuevos `page-visibility.test.ts` y `report-content-visibility.test.tsx` actualizado al nuevo comportamiento)
- Validación visual del PDF/preview en staging: pendiente tras deploy (la verificación e2e corre contra staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)