### PR TITLE
fix: no inventar "Bueno" en aspecto general del informe laboral

### DIFF
--- a/src/common/helpers/maps.ts
+++ b/src/common/helpers/maps.ts
@@ -92,7 +92,7 @@ export interface ExamenFisicoItem {
 
 
 interface MedicalEvaluation {
-    aspectoGeneral: "Bueno" | "Regular" | "Malo",
+    aspectoGeneral: "" | "Bueno" | "Regular" | "Malo",
     tiempoLibre: string,
 }
 
@@ -513,8 +513,10 @@ export function mapRespiratorio(dataValues: DataValue[]): Respiratorio {
 }
 
 export function aspectoGeneralyTiempolibre(dataValues: DataValue[]): MedicalEvaluation {
+    // Sin dato cargado, aspecto general queda vacio (no se inventa "Bueno"):
+    // asi la seccion/pagina clinica no aparece si el medico no lo evaluo.
     const data: MedicalEvaluation = {
-        aspectoGeneral: "Bueno",
+        aspectoGeneral: "",
         tiempoLibre: "",
 
     };

--- a/src/components/Pre-Occupational/Preview/Pdf/Second-Page/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Second-Page/index.tsx
@@ -24,7 +24,7 @@ interface Props {
   medicalEvaluationType: string;
   antecedentes: DataValue[] | undefined;
   doctorData: DoctorSignatures;
-  aspectoGeneral: "Bueno" | "Regular" | "Malo";
+  aspectoGeneral: "" | "Bueno" | "Regular" | "Malo";
   data: IMedicalEvaluation;
   brandingConfig?: LaborReportBrandingConfig;
   pageNumber?: number;


### PR DESCRIPTION
## Resumen

Follow-up de #118. Al validar la estandarización de visibilidad en staging, el e2e detectó que un examen vacío seguía mostrando la página 2 (Examen Clínico) con **Aspecto general = "Bueno"**, aunque el médico no lo había cargado (el examen tiene 0 datos en la base).

La causa: `aspectoGeneralyTiempolibre` defaulteaba `aspectoGeneral: "Bueno"` — el mismo patrón de "inventar un valor" que ya se corrigió para visión cromática en #118.

## Cambio

- `aspectoGeneralyTiempolibre` ahora defaultea `aspectoGeneral: ""` cuando no hay dato. Si el médico no lo evaluó, no aparece y no fuerza la página clínica.
- Tipo ajustado (`"" | "Bueno" | "Regular" | "Malo"`).

Con esto, un examen realmente vacío no imprime la página 2 — se cierra el caso pendiente de la regla "lo cargado aparece, lo vacío no".

## Test plan

- `npm run type-check` ✅
- `npm run build` ✅
- `npm run lint` ✅
- `npm run test:run` (maps + preview) ✅
- E2E `tools/e2e-laboral/tests/11-visibilidad-estandar.spec.ts` pasa a verde post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)