### PR TITLE
fix: no preseleccionar "Normal" en visión cromática del editor laboral

### DIFF
--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/Visual/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/Visual/index.tsx
@@ -16,7 +16,7 @@ interface VisualAcuityProps {
   isEditing: boolean;
   withoutCorrection: { right: string; left: string };
   withCorrection:  { right: string; left: string };
-  chromaticVision: "normal" | "anormal";
+  chromaticVision?: "normal" | "anormal";
   notes: string;
   onScChange: (eye: "right" | "left", value: string) => void;
   onCcChange: (eye: "right" | "left", value: string) => void;
@@ -93,7 +93,13 @@ export function VisualAcuityCard({
         <BooleanChoiceField
           idPrefix="vision-cromatica"
           label="Resultado"
-          value={chromaticVision === "normal"}
+          value={
+            chromaticVision === "normal"
+              ? true
+              : chromaticVision === "anormal"
+              ? false
+              : undefined
+          }
           disabled={!isEditing}
           positiveLabel="Normal"
           negativeLabel="Anormal"

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/index.tsx
@@ -347,7 +347,7 @@ export default function MedicalEvaluationAccordion({
     right: medicalEvaluation.agudezaCc?.right ?? "",
     left: medicalEvaluation.agudezaCc?.left ?? "",
   };
-  const chromatic = medicalEvaluation.visionCromatica ?? "normal";
+  const chromatic = medicalEvaluation.visionCromatica;
   const notes = medicalEvaluation.notasVision ?? "";
 
   const handleChromaticChange = (val: "normal" | "anormal") => {

--- a/src/store/Pre-Occupational/preOccupationalSlice.ts
+++ b/src/store/Pre-Occupational/preOccupationalSlice.ts
@@ -281,7 +281,7 @@ const initialState: PreOccupationalState = {
       },
       agudezaSc: { right: "", left: "" },
       agudezaCc: { right: "", left: "" },
-      visionCromatica: "normal",
+      visionCromatica: undefined,
       notasVision: "",
       circulatorio: {
         frecuenciaCardiaca: "",


### PR DESCRIPTION
## Resumen

Cierra el último caso pendiente de la estandarización de visibilidad (#118, #119), ahora del lado del **editor** del examen.

El formulario de evaluación médica preseleccionaba **"Normal"** en visión cromática aunque el médico no la hubiera cargado, por dos defaults: el `initialState` del slice (`visionCromatica: "normal"`) y un `?? "normal"` en el componente. Eso inducía a pensar que el campo estaba evaluado.

## Cambio

- `initialState` del slice: `visionCromatica` arranca `undefined`.
- Editor: se quita el `?? "normal"`; el radio de visión cromática usa tri-estado (`true`/`false`/`undefined`) y queda **sin selección** hasta que el médico elige.
- Prop `chromaticVision` del `VisualAcuityCard` pasa a opcional.

El guardado ya solo persiste el valor si está seteado, así que un examen sin cargar no guarda ni muestra visión cromática (consistente con el informe).

## Test plan

- `npm run type-check` ✅
- `npm run build` ✅
- `npm run lint` ✅
- `npm run test:run` (editor + slice + maps, 46 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)