### PR TITLE
fix: Evoluciones SFS importadas visible solo para el medico

### DIFF
--- a/src/components/Patients/Profile/SfsSyncButton.tsx
+++ b/src/components/Patients/Profile/SfsSyncButton.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { useSfsSync } from "@/hooks/Patient/useSfsSync";
 import { useToastContext } from "@/hooks/Toast/toast-context";
+import useUserRole from "@/hooks/useRoles";
 import { Download, CheckCircle } from "lucide-react";
 
 interface SfsSyncButtonProps {
@@ -19,8 +20,14 @@ interface SfsSyncButtonProps {
 
 export default function SfsSyncButton({ patientId }: SfsSyncButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const { isDoctor } = useUserRole();
   const { sfsStatus, isLoadingStatus, syncMutation } = useSfsSync(patientId);
   const { promiseToast } = useToastContext();
+
+  // Las evoluciones SFS importadas solo las ve/gestiona el medico.
+  if (!isDoctor) {
+    return null;
+  }
 
   if (isLoadingStatus || !sfsStatus?.hasData) {
     return null;

--- a/src/components/Patients/Profile/index.tsx
+++ b/src/components/Patients/Profile/index.tsx
@@ -363,9 +363,7 @@ function PatientProfileComponent({
                   </Button>
                 </>
               ))}
-            {(isSecretary || isAdmin || isDoctor) && (
-              <SfsSyncButton patientId={patient.id} />
-            )}
+            {isDoctor && <SfsSyncButton patientId={patient.id} />}
           </div>
         }
       />


### PR DESCRIPTION
## Resumen

En el perfil del paciente, el botón/sección **"Evoluciones SFS importadas"** (e "Importar N evoluciones SFS") se mostraba a **secretaria, administrador y médico**. Debe verlo **solo el médico**.

## Cambio

- `Patients/Profile/index.tsx`: la condición de render pasa de `(isSecretary || isAdmin || isDoctor)` a **`isDoctor`**.
- `SfsSyncButton.tsx`: guard interno `if (!isDoctor) return null;` (defensa en profundidad, por si se reutiliza en otro lado).

## Test plan

- `npm run type-check` ✅ · `npm run build` ✅ · `npm run lint` ✅
- `npm run test` (perfil de paciente, 11 tests) ✅

> Nota: esto es visibilidad de UI. Si la importación SFS debe además estar restringida a médico en el backend, conviene verificar el guard del endpoint de sync por separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)