### PR TITLE
fix(pdf): centrar el logo en el encabezado del informe laboral

### DIFF
--- a/src/components/Pre-Occupational/Preview/Pdf/Header/index.tsx
+++ b/src/components/Pre-Occupational/Preview/Pdf/Header/index.tsx
@@ -32,13 +32,13 @@ const styles = StyleSheet.create({
     backgroundColor: "#ffffff",
   },
   brandBlock: {
-    width: 110,
-    alignItems: "flex-start",
+    width: 120,
+    alignItems: "center",
     justifyContent: "center",
   },
   logo: {
-    width: 78,
-    height: 42,
+    width: 104,
+    height: 52,
     objectFit: "contain",
   },
   divider: {


### PR DESCRIPTION
## Resumen

En el PDF del informe laboral, el logo quedaba **pegado a la izquierda** de su columna y chico → se veía desbalanceado/feo (reportado sobre un PDF descargado).

## Cambio

- `brandBlock`: `alignItems` `flex-start` → `center` (logo centrado en su columna), ancho 110 → 120.
- `logo`: 78×52 → **104×52** (más presencia, sigue con `objectFit: contain`).

Solo afecta el encabezado del PDF del informe preocupacional.

## Test plan

- `npm run type-check` ✅ · `npm run build` ✅ · `npm run lint` ✅
- Verificación visual del PDF: al regenerar un informe en staging tras el deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)