### PR TITLE
fix: no perder datos del examen preocupacional y unificar bloqueo de observaciones

### DIFF
--- a/src/common/helpers/report-visibility.ts
+++ b/src/common/helpers/report-visibility.ts
@@ -49,11 +49,16 @@ export function normalizeReportVisibilityOverrides(
   }, {});
 }
 
-const normalizeGender = (gender?: string | null): string => {
+export const normalizeGender = (gender?: string | null): string => {
   if (!gender) return "";
 
   return gender.trim().toLowerCase();
 };
+
+// Los datos gineco-obstétricos (FUM, partos, cesárea, embarazos) no aplican a
+// colaboradores de sexo masculino. Mismo criterio que usa el informe/PDF.
+export const isGynObApplicable = (gender?: string | null): boolean =>
+  normalizeGender(gender) !== "masculino";
 
 export function resolveReportVisibility({
   sectionKey,

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/CirculatorioSection/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/CirculatorioSection/index.tsx
@@ -45,7 +45,10 @@ export const CirculatorioSection: React.FC<CirculatorioSectionProps> = ({
   };
 
   const handleVaricesChange = (value: boolean | undefined) => {
-    if (value === true && data.sinAlteraciones && onBatchChange) {
+    // "No" (ausente) => no hay nada que describir: limpiar la observación.
+    if (value === false && onBatchChange) {
+      onBatchChange({ varices: false, varicesObs: "" });
+    } else if (value === true && data.sinAlteraciones && onBatchChange) {
       onBatchChange({ sinAlteraciones: false, varices: true });
     } else {
       onChange("varices", value);
@@ -53,15 +56,13 @@ export const CirculatorioSection: React.FC<CirculatorioSectionProps> = ({
   };
 
   const handleVaricesObsChange = (value: string) => {
-    if (value.trim() && data.sinAlteraciones && onBatchChange) {
-      onBatchChange({ sinAlteraciones: false, varicesObs: value });
-    } else {
-      onChange("varicesObs", value);
-    }
+    onChange("varicesObs", value);
   };
 
-  // Solo las observaciones se deshabilitan, los checkboxes Sí/No siempre habilitados
+  // Observaciones del estado general: se bloquean con "Sin alteraciones".
   const obsDisabled = !isEditing || data.sinAlteraciones;
+  // Observaciones de várices: solo si hay várices presentes ("Si").
+  const varicesObsDisabled = !isEditing || data.varices !== true;
   const sinAlteracionesValue =
     data.sinAlteraciones === true ? "si" : data.sinAlteraciones === false ? "no" : "";
   const varicesValue =
@@ -162,9 +163,13 @@ export const CirculatorioSection: React.FC<CirculatorioSectionProps> = ({
           id="circ-varices-obs"
           label="Observaciones"
           value={data.varicesObs || ""}
-          disabled={obsDisabled}
+          disabled={varicesObsDisabled}
           onChange={handleVaricesObsChange}
-          placeholder="Detalle clínico o aclaraciones"
+          placeholder={
+            varicesObsDisabled
+              ? "Sin observaciones"
+              : "Detalle clínico o aclaraciones"
+          }
         />
       </ClinicalBlock>
     </div>

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/GenitourinarioSection/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/GenitourinarioSection/index.tsx
@@ -46,7 +46,10 @@ export const GenitourinarioSection: React.FC<GenitourinarioSectionProps> = ({
   };
 
   const handleVaricoceleChange = (value: boolean | undefined) => {
-    if (value === true && data.sinAlteraciones && onBatchChange) {
+    // "No" (ausente) => no hay nada que describir: limpiar la observación.
+    if (value === false && onBatchChange) {
+      onBatchChange({ varicocele: false, varicoceleObs: "" });
+    } else if (value === true && data.sinAlteraciones && onBatchChange) {
       onBatchChange({ sinAlteraciones: false, varicocele: true });
     } else {
       onChange("varicocele", value);
@@ -54,15 +57,13 @@ export const GenitourinarioSection: React.FC<GenitourinarioSectionProps> = ({
   };
 
   const handleVaricoceleObsChange = (value: string) => {
-    if (value.trim() && data.sinAlteraciones && onBatchChange) {
-      onBatchChange({ sinAlteraciones: false, varicoceleObs: value });
-    } else {
-      onChange("varicoceleObs", value);
-    }
+    onChange("varicoceleObs", value);
   };
 
-  // Solo las observaciones se deshabilitan, los checkboxes Sí/No siempre habilitados
+  // Observaciones del estado general: se bloquean con "Sin alteraciones".
   const obsDisabled = !isEditing || data.sinAlteraciones;
+  // Observaciones de varicocele: solo si hay varicocele presente ("Si").
+  const varicoceleObsDisabled = !isEditing || data.varicocele !== true;
   const sinAlteracionesValue =
     data.sinAlteraciones === true ? "si" : data.sinAlteraciones === false ? "no" : "";
   const varicoceleValue =
@@ -121,9 +122,13 @@ export const GenitourinarioSection: React.FC<GenitourinarioSectionProps> = ({
           id="gen-varicocele-obs"
           label="Observaciones"
           value={data.varicoceleObs}
-          disabled={obsDisabled}
+          disabled={varicoceleObsDisabled}
           onChange={handleVaricoceleObsChange}
-          placeholder="Detalle clínico o aclaraciones"
+          placeholder={
+            varicoceleObsDisabled
+              ? "Sin observaciones"
+              : "Detalle clínico o aclaraciones"
+          }
         />
       </ClinicalBlock>
 

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/GenitourinarioSection/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/GenitourinarioSection/index.tsx
@@ -7,6 +7,7 @@ import {
   ClinicalBlock,
   NotesField,
 } from "../FormPrimitives";
+import { isGynObApplicable } from "@/common/helpers/report-visibility";
 
 interface GenitourinarioSectionProps {
   isEditing: boolean;
@@ -16,6 +17,7 @@ interface GenitourinarioSectionProps {
     value: boolean | string | undefined
   ) => void;
   onBatchChange?: (updates: Partial<Genitourinario>) => void;
+  collaboratorGender?: string;
 }
 
 export const GenitourinarioSection: React.FC<GenitourinarioSectionProps> = ({
@@ -23,7 +25,10 @@ export const GenitourinarioSection: React.FC<GenitourinarioSectionProps> = ({
   data,
   onChange,
   onBatchChange,
+  collaboratorGender,
 }) => {
+  // Los datos gineco-obstétricos no aplican a colaboradores de sexo masculino.
+  const gynObApplicable = isGynObApplicable(collaboratorGender);
   const handleSinAlteracionesChange = (checked: boolean) => {
     if (checked && onBatchChange) {
       onBatchChange({
@@ -132,60 +137,67 @@ export const GenitourinarioSection: React.FC<GenitourinarioSectionProps> = ({
         />
       </ClinicalBlock>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor="gen-fum" className="text-sm font-medium text-slate-700">
-            F.U.M
-          </Label>
-          <Input
-            id="gen-fum"
-            type="date"
-            className="w-full bg-white"
-            value={data.fum}
-            disabled={!isEditing}
-            onChange={(e) => onChange("fum", e.currentTarget.value)}
-          />
+      {gynObApplicable ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="gen-fum" className="text-sm font-medium text-slate-700">
+              F.U.M
+            </Label>
+            <Input
+              id="gen-fum"
+              type="date"
+              className="w-full bg-white"
+              value={data.fum}
+              disabled={!isEditing}
+              onChange={(e) => onChange("fum", e.currentTarget.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="gen-partos" className="text-sm font-medium text-slate-700">
+              Partos
+            </Label>
+            <Input
+              id="gen-partos"
+              type="text"
+              className="w-full bg-white"
+              value={data.partos}
+              disabled={!isEditing}
+              onChange={(e) => onChange("partos", e.currentTarget.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="gen-embarazos" className="text-sm font-medium text-slate-700">
+              Embarazos
+            </Label>
+            <Input
+              id="gen-embarazos"
+              type="text"
+              className="w-full bg-white"
+              value={data.embarazos}
+              disabled={!isEditing}
+              onChange={(e) => onChange("embarazos", e.currentTarget.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="gen-cesarea" className="text-sm font-medium text-slate-700">
+              Cesárea
+            </Label>
+            <Input
+              id="gen-cesarea"
+              type="text"
+              className="w-full bg-white"
+              value={data.cesarea}
+              disabled={!isEditing}
+              onChange={(e) => onChange("cesarea", e.currentTarget.value)}
+            />
+          </div>
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="gen-partos" className="text-sm font-medium text-slate-700">
-            Partos
-          </Label>
-          <Input
-            id="gen-partos"
-            type="text"
-            className="w-full bg-white"
-            value={data.partos}
-            disabled={!isEditing}
-            onChange={(e) => onChange("partos", e.currentTarget.value)}
-          />
+      ) : (
+        <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50/70 px-4 py-3 text-sm text-slate-500">
+          Datos gineco-obstétricos (F.U.M, embarazos, partos, cesárea) no
+          aplican para colaboradores de sexo masculino.
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="gen-embarazos" className="text-sm font-medium text-slate-700">
-            Embarazos
-          </Label>
-          <Input
-            id="gen-embarazos"
-            type="text"
-            className="w-full bg-white"
-            value={data.embarazos}
-            disabled={!isEditing}
-            onChange={(e) => onChange("embarazos", e.currentTarget.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="gen-cesarea" className="text-sm font-medium text-slate-700">
-            Cesárea
-          </Label>
-          <Input
-            id="gen-cesarea"
-            type="text"
-            className="w-full bg-white"
-            value={data.cesarea}
-            disabled={!isEditing}
-            onChange={(e) => onChange("cesarea", e.currentTarget.value)}
-          />
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/OsteoArticularSection/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/OsteoArticularSection/index.tsx
@@ -11,13 +11,28 @@ interface OsteoarticularSectionProps {
   isEditing: boolean;
   data: Osteoarticular;
   onChange: (field: keyof Osteoarticular, value: boolean | string | undefined) => void;
+  onBatchChange?: (updates: Partial<Osteoarticular>) => void;
 }
 
 export const OsteoarticularSection: React.FC<OsteoarticularSectionProps> = ({
   isEditing,
   data,
   onChange,
+  onBatchChange,
 }) => {
+  // "Sin alteraciones" => no hay nada que describir: se bloquea y limpia la observación.
+  const handleEstadoChange = (
+    key: keyof Osteoarticular,
+    obsKey: keyof Osteoarticular,
+    value: boolean | undefined
+  ) => {
+    if (value === true && onBatchChange) {
+      onBatchChange({ [key]: true, [obsKey]: "" } as Partial<Osteoarticular>);
+    } else {
+      onChange(key, value);
+    }
+  };
+
   const rows = [
     {
       key: "mmssSin" as const,
@@ -44,31 +59,40 @@ export const OsteoarticularSection: React.FC<OsteoarticularSectionProps> = ({
   return (
     <div className="space-y-4">
       <div className="grid gap-3 xl:grid-cols-2">
-        {rows.map((row) => (
-          <ClinicalBlock
-            key={row.key}
-            title={row.label}
-            description="Indicá si está conservado o si hace falta aclarar hallazgos."
-          >
-            <BooleanChoiceField
-              idPrefix={row.key}
-              label="Estado"
-              value={data[row.key]}
-              disabled={!isEditing}
-              positiveLabel="Sin alteraciones"
-              negativeLabel="Con hallazgos"
-              onChange={(value) => onChange(row.key, value)}
-            />
-            <NotesField
-              id={`${row.obsKey}`}
-              label="Observaciones"
-              value={String(data[row.obsKey] ?? "")}
-              disabled={!isEditing}
-              onChange={(value) => onChange(row.obsKey, value)}
-              placeholder="Detalle clínico o aclaraciones"
-            />
-          </ClinicalBlock>
-        ))}
+        {rows.map((row) => {
+          const obsDisabled = !isEditing || data[row.key] === true;
+          return (
+            <ClinicalBlock
+              key={row.key}
+              title={row.label}
+              description="Indicá si está conservado o si hace falta aclarar hallazgos."
+            >
+              <BooleanChoiceField
+                idPrefix={row.key}
+                label="Estado"
+                value={data[row.key]}
+                disabled={!isEditing}
+                positiveLabel="Sin alteraciones"
+                negativeLabel="Con hallazgos"
+                onChange={(value) =>
+                  handleEstadoChange(row.key, row.obsKey, value)
+                }
+              />
+              <NotesField
+                id={`${row.obsKey}`}
+                label="Observaciones"
+                value={String(data[row.obsKey] ?? "")}
+                disabled={obsDisabled}
+                onChange={(value) => onChange(row.obsKey, value)}
+                placeholder={
+                  obsDisabled
+                    ? "Sin observaciones"
+                    : "Detalle clínico o aclaraciones"
+                }
+              />
+            </ClinicalBlock>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/ToraxSection/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/ToraxSection/index.tsx
@@ -10,78 +10,102 @@ interface ToraxSectionProps {
   isEditing: boolean;
   data: Torax;
   onChange: (field: keyof Torax, value: "si" | "no" | string | undefined) => void;
+  onBatchChange?: (updates: Partial<Torax>) => void;
 }
 
 export const ToraxSection: React.FC<ToraxSectionProps> = ({
   isEditing,
   data,
   onChange,
-}) => (
-  <div className="space-y-4">
-    <div className="grid gap-3 xl:grid-cols-2">
-      <ClinicalBlock
-        title="Deformaciones"
-        description="Indicá si hay deformaciones torácicas y agregá observaciones si corresponde."
-      >
-        <BooleanChoiceField
-          idPrefix="torax-def"
-          label="Presencia"
-          value={
-            data.deformaciones === "si"
-              ? true
-              : data.deformaciones === "no"
-                ? false
-                : undefined
-          }
-          disabled={!isEditing}
-          onChange={(value) =>
-            onChange(
-              'deformaciones',
-              value === true ? 'si' : value === false ? 'no' : undefined
-            )
-          }
-        />
-        <NotesField
-          id="torax-def-obs"
-          label="Observaciones"
-          value={data.deformacionesObs}
-          disabled={!isEditing}
-          onChange={(value) => onChange('deformacionesObs', value)}
-          placeholder="Detalle clínico o aclaraciones"
-        />
-      </ClinicalBlock>
+  onBatchChange,
+}) => {
+  // Las observaciones solo tienen sentido cuando el hallazgo está presente ("Si").
+  // Si se marca "No" (ausente), se bloquea y se limpia la observación.
+  const handlePresenciaChange = (
+    field: "deformaciones" | "cicatrices",
+    obsField: "deformacionesObs" | "cicatricesObs",
+    value: boolean | undefined
+  ) => {
+    const next = value === true ? "si" : value === false ? "no" : undefined;
+    if (value !== true && onBatchChange) {
+      onBatchChange({ [field]: next, [obsField]: "" } as Partial<Torax>);
+    } else {
+      onChange(field, next);
+    }
+  };
 
-      <ClinicalBlock
-        title="Cicatrices"
-        description="Indicá si hay cicatrices y agregá observaciones si hace falta."
-      >
-        <BooleanChoiceField
-          idPrefix="torax-cic"
-          label="Presencia"
-          value={
-            data.cicatrices === "si"
-              ? true
-              : data.cicatrices === "no"
-                ? false
-                : undefined
-          }
-          disabled={!isEditing}
-          onChange={(value) =>
-            onChange(
-              'cicatrices',
-              value === true ? 'si' : value === false ? 'no' : undefined
-            )
-          }
-        />
-        <NotesField
-          id="torax-cic-obs"
-          label="Observaciones"
-          value={data.cicatricesObs}
-          disabled={!isEditing}
-          onChange={(value) => onChange('cicatricesObs', value)}
-          placeholder="Detalle clínico o aclaraciones"
-        />
-      </ClinicalBlock>
+  const deformacionesObsDisabled = !isEditing || data.deformaciones !== "si";
+  const cicatricesObsDisabled = !isEditing || data.cicatrices !== "si";
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 xl:grid-cols-2">
+        <ClinicalBlock
+          title="Deformaciones"
+          description="Indicá si hay deformaciones torácicas y agregá observaciones si corresponde."
+        >
+          <BooleanChoiceField
+            idPrefix="torax-def"
+            label="Presencia"
+            value={
+              data.deformaciones === "si"
+                ? true
+                : data.deformaciones === "no"
+                  ? false
+                  : undefined
+            }
+            disabled={!isEditing}
+            onChange={(value) =>
+              handlePresenciaChange("deformaciones", "deformacionesObs", value)
+            }
+          />
+          <NotesField
+            id="torax-def-obs"
+            label="Observaciones"
+            value={data.deformacionesObs}
+            disabled={deformacionesObsDisabled}
+            onChange={(value) => onChange('deformacionesObs', value)}
+            placeholder={
+              deformacionesObsDisabled
+                ? "Sin observaciones"
+                : "Detalle clínico o aclaraciones"
+            }
+          />
+        </ClinicalBlock>
+
+        <ClinicalBlock
+          title="Cicatrices"
+          description="Indicá si hay cicatrices y agregá observaciones si hace falta."
+        >
+          <BooleanChoiceField
+            idPrefix="torax-cic"
+            label="Presencia"
+            value={
+              data.cicatrices === "si"
+                ? true
+                : data.cicatrices === "no"
+                  ? false
+                  : undefined
+            }
+            disabled={!isEditing}
+            onChange={(value) =>
+              handlePresenciaChange("cicatrices", "cicatricesObs", value)
+            }
+          />
+          <NotesField
+            id="torax-cic-obs"
+            label="Observaciones"
+            value={data.cicatricesObs}
+            disabled={cicatricesObsDisabled}
+            onChange={(value) => onChange('cicatricesObs', value)}
+            placeholder={
+              cicatricesObsDisabled
+                ? "Sin observaciones"
+                : "Detalle clínico o aclaraciones"
+            }
+          />
+        </ClinicalBlock>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/index.tsx
@@ -166,6 +166,16 @@ export default function MedicalEvaluationAccordion({
       })
     );
   };
+  const handleToraxBatchChange = (updates: Partial<Torax>) => {
+    dispatch(
+      setFormData({
+        medicalEvaluation: {
+          ...medicalEvaluation,
+          torax: { ...toraxData, ...updates },
+        },
+      })
+    );
+  };
 
   const resp: Respiratorio = medicalEvaluation.respiratorio ?? {
     sinAlteraciones: undefined,
@@ -236,6 +246,16 @@ export default function MedicalEvaluationAccordion({
             ...osteo,
             [field]: value,
           },
+        },
+      })
+    );
+  };
+  const handleOsteoBatchChange = (updates: Partial<Osteoarticular>) => {
+    dispatch(
+      setFormData({
+        medicalEvaluation: {
+          ...medicalEvaluation,
+          osteoarticular: { ...osteo, ...updates },
         },
       })
     );
@@ -748,6 +768,7 @@ const handleNeuChange = (
           isEditing={isEditing}
           data={toraxData}
           onChange={handleToraxChange}
+          onBatchChange={handleToraxBatchChange}
         />
       </EvaluationSection>
 
@@ -801,6 +822,7 @@ const handleNeuChange = (
           isEditing={isEditing}
           data={osteo}
           onChange={handleOsteoChange}
+          onBatchChange={handleOsteoBatchChange}
         />
       </EvaluationSection>
     </div>

--- a/src/components/Accordion/Pre-Occupational/Medical-Evaluation/index.tsx
+++ b/src/components/Accordion/Pre-Occupational/Medical-Evaluation/index.tsx
@@ -35,6 +35,7 @@ import { ClinicalBlock } from "./FormPrimitives";
 interface Props {
   isEditing: boolean;
   standalone?: boolean;
+  collaboratorGender?: string;
 }
 
 interface EvaluationSectionProps {
@@ -66,6 +67,7 @@ function EvaluationSection({
 export default function MedicalEvaluationAccordion({
   isEditing,
   standalone = false,
+  collaboratorGender,
 }: Props) {
   const dispatch = useDispatch<AppDispatch>();
   const medicalEvaluation = useSelector(
@@ -814,6 +816,7 @@ const handleNeuChange = (
           data={genito}
           onChange={handleGenitoChange}
           onBatchChange={handleGenitoBatchChange}
+          collaboratorGender={collaboratorGender}
         />
       </EvaluationSection>
 

--- a/src/components/Pre-Occupational/Card/index.tsx
+++ b/src/components/Pre-Occupational/Card/index.tsx
@@ -646,6 +646,7 @@ export default function PreOccupationalCards({
                   showEditToggle={false}
                   isEditing={isEditing}
                   dataValues={dataValues}
+                  collaboratorGender={collaborator.gender}
                   medicalEvaluationId={medicalEvaluation.id}
                   setIsEditing={setIsEditing}
                   includeOccupationalHistory

--- a/src/components/Tabs/Pre-Occupational/General/index.tsx
+++ b/src/components/Tabs/Pre-Occupational/General/index.tsx
@@ -119,6 +119,7 @@ export default function GeneralTab({
   const handleSave = async () => {
     let resolvedFields = fields;
     let resolvedMappedExams = mappedExams;
+    const missingFields: string[] = [];
 
     const ensureAllFields = async () => {
       if (resolvedFields.length > 0) return resolvedFields;
@@ -179,13 +180,7 @@ export default function GeneralTab({
           value: formData.conclusion,
         });
       } else {
-        console.warn("[GeneralTab] conclusion field not resolved", {
-          availableFields: fields.map((field) => ({
-            id: field.id,
-            name: field.name,
-            category: field.category,
-          })),
-        });
+        missingFields.push("Conclusión");
       }
     }
 
@@ -216,27 +211,25 @@ export default function GeneralTab({
           value: formData.recomendaciones,
         });
       } else {
-        console.warn("[GeneralTab] recomendaciones field not resolved", {
-          availableFields: fields.map((field) => ({
-            id: field.id,
-            name: field.name,
-            category: field.category,
-          })),
-        });
+        missingFields.push("Recomendaciones");
       }
     }
 
-    console.log("[GeneralTab] save payload", {
-      medicalEvaluationId,
-      payloadItems,
-      conclusionField,
-      recomendacionesField,
+    // Resultados de estudios cargados cuyo data_type no existe en el catálogo
+    examFilter.forEach((exam) => {
+      const loaded = (formData.examResults[exam.id] || "").trim() !== "";
+      const resolved = resolvedMappedExams.some((m) => m.id === exam.id);
+      if (loaded && !resolved) missingFields.push(exam.name);
     });
 
     if (payloadItems.length === 0) {
       showError(
         "No se pudo guardar",
-        "No encontramos campos configurados para guardar los cambios de esta etapa."
+        missingFields.length > 0
+          ? `Faltan tipos de dato en el catálogo para: ${missingFields.join(
+              ", "
+            )}. Avisá a sistemas para que los habilite.`
+          : "No encontramos campos configurados para guardar los cambios de esta etapa."
       );
       return;
     }
@@ -251,10 +244,17 @@ export default function GeneralTab({
           title: "Guardando datos",
           description: "Por favor espera mientras procesamos tu solicitud",
         },
-        success: {
-          title: "Datos guardados",
-          description: "Los datos se guardaron exitosamente",
-        },
+        success:
+          missingFields.length > 0
+            ? {
+                title: "Guardado parcial",
+                description:
+                  "Algunos campos no se pudieron guardar (ver el aviso).",
+              }
+            : {
+                title: "Datos guardados",
+                description: "Los datos se guardaron exitosamente",
+              },
         error: (error: unknown) => ({
           title: "Error al guardar los datos",
           description:
@@ -263,6 +263,15 @@ export default function GeneralTab({
         }),
       }
     );
+
+    if (missingFields.length > 0) {
+      showError(
+        "Hay campos que no se guardaron",
+        `No se pudieron guardar por falta de configuración en el catálogo: ${missingFields.join(
+          ", "
+        )}. Avisá a sistemas para que los habilite.`
+      );
+    }
 
     setSavedFormData(formData);
   };

--- a/src/components/Tabs/Pre-Occupational/Medical-History/index.tsx
+++ b/src/components/Tabs/Pre-Occupational/Medical-History/index.tsx
@@ -774,6 +774,7 @@ export default function MedicalHistoryTab({
   setIsEditing,
   medicalEvaluationId,
   dataValues,
+  collaboratorGender,
   standalone = false,
   showEditToggle = true,
   includeOccupationalHistory = true,
@@ -789,6 +790,7 @@ export default function MedicalHistoryTab({
   setIsEditing: (value: boolean) => void;
   medicalEvaluationId: number;
   dataValues: DataValue[] | undefined;
+  collaboratorGender?: string;
   standalone?: boolean;
   showEditToggle?: boolean;
   includeOccupationalHistory?: boolean;
@@ -1024,6 +1026,7 @@ export default function MedicalHistoryTab({
         {includeMedicalEvaluation && (
           <MedicalEvaluationAccordion
             isEditing={isEditing}
+            collaboratorGender={collaboratorGender}
           />
         )}
       </Accordion>

--- a/src/components/Tabs/Pre-Occupational/Medical-History/index.tsx
+++ b/src/components/Tabs/Pre-Occupational/Medical-History/index.tsx
@@ -618,6 +618,80 @@ export const buildMedicalEvaluationPayload = (
   return payloadItems;
 };
 
+// Detecta campos del examen físico/clínico que el usuario cargó pero cuyo
+// data_type NO existe en el catálogo: el guardado los descartaría en silencio.
+// Mantener sincronizado con buildMedicalEvaluationPayload.
+export const getMissingMedicalEvaluationFields = (
+  fields: DataType[],
+  me: IMedicalEvaluation
+): string[] => {
+  const ec = me.examenClinico;
+  const hasText = (v?: string | number | null) =>
+    v != null && String(v).trim() !== "";
+  const hasBool = (v: unknown) =>
+    v === true || v === false || v === "si" || v === "no";
+
+  const expected: { name: string; category: string; loaded: boolean }[] = [
+    { name: "Aspecto general", category: "HISTORIA_MEDICA", loaded: hasText(me.aspectoGeneral) },
+    { name: "Tiempo libre", category: "HISTORIA_MEDICA", loaded: hasText(me.tiempoLibre) },
+    { name: "Talla", category: "EXAMEN_CLINICO", loaded: hasText(ec.talla) },
+    { name: "Peso", category: "EXAMEN_CLINICO", loaded: hasText(ec.peso) },
+    { name: "IMC", category: "EXAMEN_CLINICO", loaded: hasText(ec.imc) },
+    { name: "Perimetro Abdominal", category: "EXAMEN_CLINICO", loaded: hasText(ec.perimetroAbdominal) },
+    { name: "Presión Sistólica", category: "EXAMEN_CLINICO", loaded: hasText(ec.presionSistolica) },
+    { name: "Presión Diastólica", category: "EXAMEN_CLINICO", loaded: hasText(ec.presionDiastolica) },
+    { name: "Frecuencia Cardíaca", category: "EXAMEN_CLINICO", loaded: hasText(ec.frecuenciaCardiaca) },
+    { name: "Frecuencia Respiratoria", category: "EXAMEN_CLINICO", loaded: hasText(ec.frecuenciaRespiratoria) },
+    { name: "Oximetria", category: "EXAMEN_CLINICO", loaded: hasText(me.respiratorio?.oximetria) },
+    { name: "TA", category: "EXAMEN_CLINICO", loaded: hasText(me.circulatorio?.presion) },
+    { name: "Agudeza S/C Derecho", category: "EXAMEN_CLINICO", loaded: hasText(me.agudezaSc?.right) },
+    { name: "Agudeza S/C Izquierdo", category: "EXAMEN_CLINICO", loaded: hasText(me.agudezaSc?.left) },
+    { name: "Agudeza C/C Derecho", category: "EXAMEN_CLINICO", loaded: hasText(me.agudezaCc?.right) },
+    { name: "Agudeza C/C Izquierdo", category: "EXAMEN_CLINICO", loaded: hasText(me.agudezaCc?.left) },
+    { name: "Visión Cromática", category: "EXAMEN_CLINICO", loaded: hasText(me.visionCromatica) },
+    { name: "FUM", category: "EXAMEN_FISICO", loaded: hasText(me.genitourinario?.fum) },
+    { name: "Partos", category: "EXAMEN_FISICO", loaded: hasText(me.genitourinario?.partos) },
+    { name: "Cesárea", category: "EXAMEN_FISICO", loaded: hasText(me.genitourinario?.cesarea) },
+    { name: "Embarazos", category: "EXAMEN_FISICO", loaded: hasText(me.genitourinario?.embarazos) },
+    { name: "Observaciones Cabeza y Cuello", category: "EXAMEN_FISICO", loaded: hasText(me.cabezaCuello?.observaciones) },
+    { name: "Bucodental – Observaciones", category: "EXAMEN_FISICO", loaded: hasText(me.bucodental?.observaciones) },
+    { name: "Normocoloreada", category: "EXAMEN_FISICO", loaded: hasBool(me.piel?.normocoloreada) },
+    { name: "Tatuajes", category: "EXAMEN_FISICO", loaded: hasBool(me.piel?.tatuajes) },
+    { name: "Cabeza y Cuello", category: "EXAMEN_FISICO", loaded: hasBool(me.cabezaCuello?.sinAlteraciones) },
+    { name: "Bucodental – Sin alteraciones", category: "EXAMEN_FISICO", loaded: hasBool(me.bucodental?.sinAlteraciones) },
+    { name: "Bucodental – Caries", category: "EXAMEN_FISICO", loaded: hasBool(me.bucodental?.caries) },
+    { name: "Bucodental – Faltan piezas", category: "EXAMEN_FISICO", loaded: hasBool(me.bucodental?.faltanPiezas) },
+    { name: "Torax Deformaciones", category: "EXAMEN_FISICO", loaded: hasBool(me.torax?.deformaciones) },
+    { name: "Torax Cicatrices", category: "EXAMEN_FISICO", loaded: hasBool(me.torax?.cicatrices) },
+    { name: "Aparato Respiratorio", category: "EXAMEN_FISICO", loaded: hasBool(me.respiratorio?.sinAlteraciones) },
+    { name: "Aparato Circulatorio", category: "EXAMEN_FISICO", loaded: hasBool(me.circulatorio?.sinAlteraciones) },
+    { name: "Várices", category: "EXAMEN_FISICO", loaded: hasBool(me.circulatorio?.varices) },
+    { name: "Aparato Gastrointestinal", category: "EXAMEN_FISICO", loaded: hasBool(me.gastrointestinal?.sinAlteraciones) },
+    { name: "Cicatrices", category: "EXAMEN_FISICO", loaded: hasBool(me.gastrointestinal?.cicatrices) },
+    { name: "Hernias", category: "EXAMEN_FISICO", loaded: hasBool(me.gastrointestinal?.hernias) },
+    { name: "Eventraciones", category: "EXAMEN_FISICO", loaded: hasBool(me.gastrointestinal?.eventraciones) },
+    { name: "Hemorroides", category: "EXAMEN_FISICO", loaded: hasBool(me.gastrointestinal?.hemorroides) },
+    { name: "Aparato Neurológico", category: "EXAMEN_FISICO", loaded: hasBool(me.neurologico?.sinAlteraciones) },
+    { name: "Aparato Genitourinario", category: "EXAMEN_FISICO", loaded: hasBool(me.genitourinario?.sinAlteraciones) },
+    { name: "Varicocele", category: "EXAMEN_FISICO", loaded: hasBool(me.genitourinario?.varicocele) },
+    { name: "MMSS Sin Alteraciones", category: "EXAMEN_FISICO", loaded: hasBool(me.osteoarticular?.mmssSin) },
+    { name: "MMII Sin Alteraciones", category: "EXAMEN_FISICO", loaded: hasBool(me.osteoarticular?.mmiiSin) },
+    { name: "Columna Sin Alteraciones", category: "EXAMEN_FISICO", loaded: hasBool(me.osteoarticular?.columnaSin) },
+    { name: "Amputaciones", category: "EXAMEN_FISICO", loaded: hasBool(me.osteoarticular?.amputaciones) },
+  ];
+
+  const norm = (s: string) => s.normalize("NFC").trim().toLowerCase();
+  return expected
+    .filter((e) => e.loaded)
+    .filter(
+      (e) =>
+        !(fields ?? []).some(
+          (f) => f.category === e.category && norm(f.name) === norm(e.name)
+        )
+    )
+    .map((e) => e.name);
+};
+
 const CLEARABLE_MEDICAL_EVALUATION_FIELD_NAMES = new Set([
   "Aspecto general",
   "Tiempo libre",
@@ -740,7 +814,7 @@ export default function MedicalHistoryTab({
   });
   const { createDataValuesMutation, deleteDataValuesMutation } =
     useDataValuesMutations();
-  const { promiseToast } = useToastContext();
+  const { promiseToast, showError } = useToastContext();
   const formData = useSelector(
     (state: RootState) => state.preOccupational.formData
   );
@@ -838,6 +912,9 @@ export default function MedicalHistoryTab({
   };
 
   const handleSave = async () => {
+    const missingFields = includeMedicalEvaluation
+      ? getMissingMedicalEvaluationFields(fields, medicalEvaluation)
+      : [];
     const savePromise = (async () => {
       if (deletedOccupationalHistoryIds.length > 0) {
         await Promise.all(
@@ -866,16 +943,31 @@ export default function MedicalHistoryTab({
         title: "Guardando datos",
         description: "Por favor espera mientras procesamos tu solicitud",
       },
-      success: {
-        title: "Datos guardados",
-        description: "Los datos se guardaron exitosamente",
-      },
+      success:
+        missingFields.length > 0
+          ? {
+              title: "Guardado parcial",
+              description:
+                "Algunos campos no se pudieron guardar (ver el aviso).",
+            }
+          : {
+              title: "Datos guardados",
+              description: "Los datos se guardaron exitosamente",
+            },
       error: (error: unknown) => ({
         title: "Error al guardar los datos",
         description:
           (error as { response?: { data?: { message?: string } } }).response?.data?.message || "Ha ocurrido un error inesperado",
       }),
     });
+    if (missingFields.length > 0) {
+      showError(
+        "Hay campos que no se guardaron",
+        `No se pudieron guardar por falta de configuración en el catálogo: ${missingFields.join(
+          ", "
+        )}. Avisá a sistemas para que los habilite.`
+      );
+    }
     // Invalidar queries para forzar recarga de datos frescos
     queryClient.invalidateQueries({ queryKey: ["collaborator-medical-evaluation"] });
     queryClient.invalidateQueries({ queryKey: ["data-values"] });


### PR DESCRIPTION
## Problema

En el examen preocupacional, al cargar campos como **Embarazos** o **Cesárea** en "Historia médica", guardar mostraba el toast verde pero el dato **no se persistía** y el PDF seguía mostrando lo anterior.

**Causa raíz:** el front busca cada `data_type` por nombre; si no existe en el catálogo, descarta el dato en silencio y muestra éxito igual. (Confirmado con repro Playwright contra staging.)

## Cambios

- **Endurecimiento (no perder en silencio):** `Medical-History` y `General` detectan los campos con valor cuyo `data_type` no resuelve y avisan con un **toast de error** (guardado parcial), en lugar de descartarlos calladamente.
- **Observaciones SI/NO unificadas:** se bloquean y limpian cuando no hay nada que describir — presencia "No" (Várices, Varicocele, Tórax) o "Sin alteraciones" (Osteoarticular). Se agrega `onBatchChange` a Tórax y Osteoarticular.

> Requiere el seed de `data_type` faltantes del PR del backend (`miportal-incor-laboral`).

## Test plan

- `npm run type-check`, `npm run lint`, `npm run build` ✅
- Repro Playwright (staging, tras seed): Embarazos/Cesárea/Conclusión ahora `persistido=true`.
- Verificación manual del bloqueo de observaciones al deployar (staging corre el código previo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)